### PR TITLE
Fix OIDC cluster auth not supported

### DIFF
--- a/main.go
+++ b/main.go
@@ -16,7 +16,10 @@ limitations under the License.
 
 package main
 
-import "github.com/corneliusweig/rakkess/cmd"
+import (
+	"github.com/corneliusweig/rakkess/cmd"
+	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
+)
 
 func main() {
 	cmd.Execute()


### PR DESCRIPTION
This fixes an issue when a Kubernetes cluster uses OIDC authentication,
e.g.

```bash
./rakkess
FATA[0000] fetch available group resources: discovery client: No Auth
Provider found for name "oidc"
```

Added a blank import for oidc from client-go as per [this](https://github.com/operator-framework/operator-sdk/issues/710#issuecomment-436795984) workaround.

Signed-off-by: Michael Gasch <embano1@live.com>