### PR TITLE
Option to display results as ASCII text

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -91,7 +91,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&v, "verbosity", "v", constants.DefaultLogLevel.String(), "Log level (debug, info, warn, error, fatal, panic)")
 
 	rootCmd.Flags().StringSliceVar(&rakkessOptions.Verbs, "verbs", []string{"list", "create", "update", "delete"}, fmt.Sprintf("show access for verbs out of %s", constants.ValidVerbs))
-	rootCmd.Flags().StringVar(&rakkessOptions.DisplayMode, "display-mode", "icons", fmt.Sprintf("display style for output out of %s", constants.ValidDisplayModes))
+	rootCmd.Flags().StringVarP(&rakkessOptions.Output, "output", "o", "icon-table", fmt.Sprintf("output format out of %s", constants.ValidOutputFormats))
 
 	rakkessOptions.ConfigFlags.AddFlags(rootCmd.Flags())
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -91,6 +91,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&v, "verbosity", "v", constants.DefaultLogLevel.String(), "Log level (debug, info, warn, error, fatal, panic)")
 
 	rootCmd.Flags().StringSliceVar(&rakkessOptions.Verbs, "verbs", []string{"list", "create", "update", "delete"}, fmt.Sprintf("show access for verbs out of %s", constants.ValidVerbs))
+	rootCmd.Flags().StringVar(&rakkessOptions.DisplayMode, "display-mode", "icons", fmt.Sprintf("display style for output out of %s", constants.ValidDisplayModes))
 
 	rakkessOptions.ConfigFlags.AddFlags(rootCmd.Flags())
 

--- a/pkg/rakkess/constants/constants.go
+++ b/pkg/rakkess/constants/constants.go
@@ -32,8 +32,8 @@ var (
 		"delete",
 		"proxy",
 	}
-	ValidDisplayModes = []string{
-		"icons",
-		"ascii",
+	ValidOutputFormats = []string{
+		"icon-table",
+		"ascii-table",
 	}
 )

--- a/pkg/rakkess/constants/constants.go
+++ b/pkg/rakkess/constants/constants.go
@@ -32,4 +32,8 @@ var (
 		"delete",
 		"proxy",
 	}
+	ValidDisplayModes = []string{
+		"icons",
+		"ascii",
+	}
 )

--- a/pkg/rakkess/options/options.go
+++ b/pkg/rakkess/options/options.go
@@ -27,6 +27,7 @@ import (
 type RakkessOptions struct {
 	ConfigFlags *genericclioptions.ConfigFlags
 	Verbs       []string
+	DisplayMode string
 	Streams     *genericclioptions.IOStreams
 }
 

--- a/pkg/rakkess/options/options.go
+++ b/pkg/rakkess/options/options.go
@@ -27,7 +27,7 @@ import (
 type RakkessOptions struct {
 	ConfigFlags *genericclioptions.ConfigFlags
 	Verbs       []string
-	DisplayMode string
+	Output      string
 	Streams     *genericclioptions.IOStreams
 }
 

--- a/pkg/rakkess/rakkess.go
+++ b/pkg/rakkess/rakkess.go
@@ -48,11 +48,21 @@ func Rakkess(ctx context.Context, opts *options.RakkessOptions) error {
 		return errors.Wrap(err, "check resource access")
 	}
 
-	util.PrintResults(opts.Streams.Out, opts.Verbs, results)
+	util.PrintResults(opts.Streams.Out, opts.Verbs, printOptions(opts), results)
 
 	if namespace == nil || *namespace == "" {
 		logrus.Warn("No namespace given, this implies cluster scope (try -n if this is not intended)")
 	}
 
 	return nil
+}
+
+func printOptions(o *options.RakkessOptions) util.PrintOptions {
+	displayMode := util.Icons
+	if o.DisplayMode == "ascii" {
+		displayMode = util.ASCII
+	}
+	return util.PrintOptions {
+		DisplayMode: displayMode,
+	}
 }

--- a/pkg/rakkess/rakkess.go
+++ b/pkg/rakkess/rakkess.go
@@ -30,6 +30,9 @@ func Rakkess(ctx context.Context, opts *options.RakkessOptions) error {
 	if err := util.ValidateVerbs(opts.Verbs); err != nil {
 		return err
 	}
+	if err := util.ValidateOutputFormat(opts.Output); err != nil {
+		return err
+	}
 
 	grs, err := client.FetchAvailableGroupResources(opts)
 	if err != nil {

--- a/pkg/rakkess/rakkess.go
+++ b/pkg/rakkess/rakkess.go
@@ -62,7 +62,7 @@ func printOptions(o *options.RakkessOptions) util.PrintOptions {
 	if o.DisplayMode == "ascii" {
 		displayMode = util.ASCII
 	}
-	return util.PrintOptions {
+	return util.PrintOptions{
 		DisplayMode: displayMode,
 	}
 }

--- a/pkg/rakkess/rakkess.go
+++ b/pkg/rakkess/rakkess.go
@@ -48,7 +48,7 @@ func Rakkess(ctx context.Context, opts *options.RakkessOptions) error {
 		return errors.Wrap(err, "check resource access")
 	}
 
-	util.PrintResults(opts.Streams.Out, opts.Verbs, printOptions(opts), results)
+	util.PrintResults(opts.Streams.Out, opts.Verbs, outputFormat(opts), results)
 
 	if namespace == nil || *namespace == "" {
 		logrus.Warn("No namespace given, this implies cluster scope (try -n if this is not intended)")
@@ -57,12 +57,9 @@ func Rakkess(ctx context.Context, opts *options.RakkessOptions) error {
 	return nil
 }
 
-func printOptions(o *options.RakkessOptions) util.PrintOptions {
-	displayMode := util.Icons
-	if o.DisplayMode == "ascii" {
-		displayMode = util.ASCII
+func outputFormat(o *options.RakkessOptions) util.OutputFormat {
+	if o.Output == "ascii-table" {
+		return util.ASCIITable
 	}
-	return util.PrintOptions{
-		DisplayMode: displayMode,
-	}
+	return util.IconTable
 }

--- a/pkg/rakkess/util/printer.go
+++ b/pkg/rakkess/util/printer.go
@@ -37,7 +37,18 @@ const (
 
 var IsTerminal = isTerminal
 
-func PrintResults(out io.Writer, requestedVerbs []string, results []client.Result) {
+type DisplayMode int
+
+const (
+	Icons DisplayMode = iota
+	ASCII DisplayMode = iota
+)
+
+type PrintOptions struct {
+	DisplayMode DisplayMode
+}
+
+func PrintResults(out io.Writer, requestedVerbs []string, options PrintOptions, results []client.Result) {
 	w := NewWriter(out, 4, 8, 2, ' ', CollapseEscape^StripEscape)
 	defer w.Flush()
 
@@ -50,6 +61,9 @@ func PrintResults(out io.Writer, requestedVerbs []string, results []client.Resul
 	codeConverter := humanreadableAccessCode
 	if IsTerminal(out) {
 		codeConverter = colorHumanreadableAccessCode
+	}
+	if options.DisplayMode == ASCII {
+		codeConverter = asciiAccessCode
 	}
 
 	for _, r := range results {
@@ -99,4 +113,19 @@ func codeToColor(code int) color {
 		return purple
 	}
 	return none
+}
+
+func asciiAccessCode(code int) string {
+	switch code {
+	case client.AccessAllowed:
+		return "yes"
+	case client.AccessDenied:
+		return "no"
+	case client.AccessNotApplicable:
+		return ""
+	case client.AccessRequestErr:
+		return "ERR"
+	default:
+		panic("unknown access code")
+	}
 }

--- a/pkg/rakkess/util/printer.go
+++ b/pkg/rakkess/util/printer.go
@@ -118,7 +118,7 @@ func asciiAccessCode(code int) string {
 	case client.AccessDenied:
 		return "no"
 	case client.AccessNotApplicable:
-		return ""
+		return "n/a"
 	case client.AccessRequestErr:
 		return "ERR"
 	default:

--- a/pkg/rakkess/util/printer.go
+++ b/pkg/rakkess/util/printer.go
@@ -37,18 +37,14 @@ const (
 
 var IsTerminal = isTerminal
 
-type DisplayMode int
+type OutputFormat int
 
 const (
-	Icons DisplayMode = iota
-	ASCII DisplayMode = iota
+	IconTable  OutputFormat = iota
+	ASCIITable OutputFormat = iota
 )
 
-type PrintOptions struct {
-	DisplayMode DisplayMode
-}
-
-func PrintResults(out io.Writer, requestedVerbs []string, options PrintOptions, results []client.Result) {
+func PrintResults(out io.Writer, requestedVerbs []string, outputFormat OutputFormat, results []client.Result) {
 	w := NewWriter(out, 4, 8, 2, ' ', CollapseEscape^StripEscape)
 	defer w.Flush()
 
@@ -62,7 +58,7 @@ func PrintResults(out io.Writer, requestedVerbs []string, options PrintOptions, 
 	if IsTerminal(out) {
 		codeConverter = colorHumanreadableAccessCode
 	}
-	if options.DisplayMode == ASCII {
+	if outputFormat == ASCIITable {
 		codeConverter = asciiAccessCode
 	}
 

--- a/pkg/rakkess/util/printer_test.go
+++ b/pkg/rakkess/util/printer_test.go
@@ -85,7 +85,7 @@ func TestPrintResults(t *testing.T) {
 			},
 			HEADER + "resource1       \n",
 			HEADER + "resource1  \033[0m\033[0m     \033[0m\033[0m\n",
-			HEADER + "resource1       \n",
+			HEADER + "resource1  n/a  n/a\n",
 		},
 		{
 			"single result, all ERR",

--- a/pkg/rakkess/util/printer_test.go
+++ b/pkg/rakkess/util/printer_test.go
@@ -125,13 +125,13 @@ func TestPrintResults(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			buf := &bytes.Buffer{}
 
-			PrintResults(buf, test.verbs, PrintOptions{DisplayMode: Icons}, test.given)
+			PrintResults(buf, test.verbs, IconTable, test.given)
 
 			assert.Equal(t, test.expected, buf.String())
 
 			buf = &bytes.Buffer{}
 
-			PrintResults(buf, test.verbs, PrintOptions{DisplayMode: ASCII}, test.given)
+			PrintResults(buf, test.verbs, ASCIITable, test.given)
 
 			assert.Equal(t, test.expectedASCII, buf.String())
 		})
@@ -149,13 +149,13 @@ func TestPrintResults(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			buf := &bytes.Buffer{}
 
-			PrintResults(buf, test.verbs, PrintOptions{DisplayMode: Icons}, test.given)
+			PrintResults(buf, test.verbs, IconTable, test.given)
 
 			assert.Equal(t, test.expectedColor, buf.String())
 
 			buf = &bytes.Buffer{}
 
-			PrintResults(buf, test.verbs, PrintOptions{DisplayMode: ASCII}, test.given)
+			PrintResults(buf, test.verbs, ASCIITable, test.given)
 
 			assert.Equal(t, test.expectedASCII, buf.String())
 		})

--- a/pkg/rakkess/util/printer_test.go
+++ b/pkg/rakkess/util/printer_test.go
@@ -55,6 +55,7 @@ func TestPrintResults(t *testing.T) {
 		given         []client.Result
 		expected      string
 		expectedColor string
+		expectedASCII string
 	}{
 		{
 			"single result, all allowed",
@@ -64,6 +65,7 @@ func TestPrintResults(t *testing.T) {
 			},
 			HEADER + "resource1  ✔    ✔\n",
 			HEADER + "resource1  \033[32m✔\033[0m    \033[32m✔\033[0m\n",
+			HEADER + "resource1  yes  yes\n",
 		},
 		{
 			"single result, all forbidden",
@@ -73,6 +75,7 @@ func TestPrintResults(t *testing.T) {
 			},
 			HEADER + "resource1  ✖    ✖\n",
 			HEADER + "resource1  \033[31m✖\033[0m    \033[31m✖\033[0m\n",
+			HEADER + "resource1  no   no\n",
 		},
 		{
 			"single result, all not applicable",
@@ -82,6 +85,7 @@ func TestPrintResults(t *testing.T) {
 			},
 			HEADER + "resource1       \n",
 			HEADER + "resource1  \033[0m\033[0m     \033[0m\033[0m\n",
+			HEADER + "resource1       \n",
 		},
 		{
 			"single result, all ERR",
@@ -91,6 +95,7 @@ func TestPrintResults(t *testing.T) {
 			},
 			HEADER + "resource1  ERR  ERR\n",
 			HEADER + "resource1  \033[35mERR\033[0m  \033[35mERR\033[0m\n",
+			HEADER + "resource1  ERR  ERR\n",
 		},
 		{
 			"single result, mixed",
@@ -100,6 +105,7 @@ func TestPrintResults(t *testing.T) {
 			},
 			HEADER + "resource1  ✖    ✔\n",
 			"",
+			HEADER + "resource1  no   yes\n",
 		},
 		{
 			"many results",
@@ -111,6 +117,7 @@ func TestPrintResults(t *testing.T) {
 			},
 			"NAME       GET\nresource1  ✖\nresource2  ✔\nresource3  ✖\n",
 			"",
+			"NAME       GET\nresource1  no\nresource2  yes\nresource3  no\n",
 		},
 	}
 
@@ -118,9 +125,15 @@ func TestPrintResults(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			buf := &bytes.Buffer{}
 
-			PrintResults(buf, test.verbs, test.given)
+			PrintResults(buf, test.verbs, PrintOptions{DisplayMode: Icons}, test.given)
 
 			assert.Equal(t, test.expected, buf.String())
+
+			buf = &bytes.Buffer{}
+
+			PrintResults(buf, test.verbs, PrintOptions{DisplayMode: ASCII}, test.given)
+
+			assert.Equal(t, test.expectedASCII, buf.String())
 		})
 	}
 
@@ -136,9 +149,15 @@ func TestPrintResults(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			buf := &bytes.Buffer{}
 
-			PrintResults(buf, test.verbs, test.given)
+			PrintResults(buf, test.verbs, PrintOptions{DisplayMode: Icons}, test.given)
 
 			assert.Equal(t, test.expectedColor, buf.String())
+
+			buf = &bytes.Buffer{}
+
+			PrintResults(buf, test.verbs, PrintOptions{DisplayMode: ASCII}, test.given)
+
+			assert.Equal(t, test.expectedASCII, buf.String())
 		})
 	}
 }

--- a/pkg/rakkess/util/validate_output_format.go
+++ b/pkg/rakkess/util/validate_output_format.go
@@ -1,0 +1,16 @@
+package util
+
+import (
+	"fmt"
+
+	"github.com/corneliusweig/rakkess/pkg/rakkess/constants"
+)
+
+func ValidateOutputFormat(format string) error {
+	for _, o := range constants.ValidOutputFormats {
+		if o == format {
+			return nil
+		}
+	}
+	return fmt.Errorf("unexpected output format: %s", format)
+}

--- a/pkg/rakkess/util/validate_output_format_test.go
+++ b/pkg/rakkess/util/validate_output_format_test.go
@@ -1,0 +1,36 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateOutputFormat(t *testing.T) {
+	tests := []struct {
+		name     string
+		format   string
+		expected string
+	}{
+		{
+			name:   "valid format",
+			format: "icon-table",
+		},
+		{
+			name:     "invalid format",
+			format:   "cassowary",
+			expected: "unexpected output format: cassowary",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual := ValidateOutputFormat(test.format)
+			if test.expected != "" {
+				assert.EqualError(t, actual, test.expected)
+			} else {
+				assert.NoError(t, actual)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This adds a new `--display-mode` command line argument, with possible values `icons` (displays the tick and cross icons, coloured if outputting to a terminal) and `ascii` (displays the words `yes` and `no`, never coloured).  The `ascii` mode is intended to be easier to consume programmatically e.g. from scripts.

I'd very much welcome feedback on the whether the CLI option feels right - I wondered whether a `-o/--output` option might be more aligned with other tools, and would be more reusable if you later wanted to add e.g. JSON?  It should be easy for me to change, and better to get it right now than to have to make a breaking change later.  Let me know your thoughts!

Finally, I believe this is formatted correctly etc., but I'm still a bit of a Go newbie especially as regards style, so please, be kind to my mistakes!

Fixes #5.