### PR TITLE
Explicitly enable color escape sequences on windows

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/imdario/mergo v0.3.7 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.5 // indirect
+	github.com/konsorten/go-windows-terminal-sequences v1.0.1
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.1 // indirect

--- a/pkg/rakkess/util/terminal_notwindows.go
+++ b/pkg/rakkess/util/terminal_notwindows.go
@@ -1,0 +1,42 @@
+// +build !windows
+
+/*
+Copyright 2019 Cornelius Weig
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// NOTICE: This implementation comes from logrus, unfortunately logrus
+// does not expose a public interface we can use to call it.
+//   https://github.com/sirupsen/logrus/blob/master/terminal_check_notappengine.go
+//   https://github.com/sirupsen/logrus/blob/master/terminal_windows.go
+
+package util
+
+import (
+	"io"
+	"os"
+
+	"golang.org/x/crypto/ssh/terminal"
+)
+
+// initTerminal enables ANSI color escape sequences. On UNIX, they are always enabled.
+func initTerminal(_ io.Writer) {
+}
+
+func isTerminal(w io.Writer) bool {
+	if f, ok := w.(*os.File); ok {
+		return terminal.IsTerminal(int(f.Fd()))
+	}
+	return false
+}

--- a/pkg/rakkess/util/terminal_windows.go
+++ b/pkg/rakkess/util/terminal_windows.go
@@ -1,0 +1,49 @@
+// +build windows
+
+/*
+Copyright 2019 Cornelius Weig
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// NOTICE: This implementation comes from logrus, unfortunately logrus
+// does not expose a public interface we can use to call it.
+//   https://github.com/sirupsen/logrus/blob/master/terminal_check_notappengine.go
+//   https://github.com/sirupsen/logrus/blob/master/terminal_windows.go
+
+package util
+
+import (
+	"io"
+	"os"
+	"syscall"
+
+	sequences "github.com/konsorten/go-windows-terminal-sequences"
+)
+
+// initTerminal enables ANSI color escape on windows. Usually, this is done by logrus, but
+// since we don't log anything before printing, we need to take care of this ourselves.
+func initTerminal(w io.Writer) {
+	if f, ok := w.(*os.File); ok {
+		sequences.EnableVirtualTerminalProcessing(syscall.Handle(f.Fd()), true)
+	}
+}
+
+func isTerminal(w io.Writer) bool {
+	if f, ok := w.(*os.File); ok {
+		var mode uint32
+		err := syscall.GetConsoleMode(syscall.Handle(f.Fd()), &mode)
+		return err == nil
+	}
+	return false
+}


### PR DESCRIPTION
The problem of colored output in PowerShell has been tackled by [logrus](https://github.com/sirupsen/logrus/blob/master/terminal_windows.go) and [konsorten](https://github.com/konsorten/go-windows-terminal-sequences). However, due to the lack of logging, the color codes are not enabled on PowerShell for `rakkess`. Therefore, this PR explicitly enables ANSI color codes in PowerShell.

Fixes #6

@itowlson Could you kindly check if this works for you?