### PR TITLE
New subcommand `resource`

### DIFF
--- a/cmd/resource.go
+++ b/cmd/resource.go
@@ -17,8 +17,8 @@ limitations under the License.
 package cmd
 
 import (
-	"fmt"
-
+	"github.com/corneliusweig/rakkess/pkg/rakkess/client"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -30,7 +30,8 @@ var resourceCmd = &cobra.Command{
 	Args:    cobra.ExactArgs(1),
 	Long:    `todo`,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("resource called")
+		sa, _ := client.GetSubjectAccess(rakkessOptions, args[0])
+		logrus.Infof("%s", sa.Get())
 	},
 }
 

--- a/cmd/resource.go
+++ b/cmd/resource.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2019 Cornelius Weig
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// resourceCmd represents the resource command
+var resourceCmd = &cobra.Command{
+	Use:     "resource",
+	Aliases: []string{"for", "for-resource"},
+	Short:   "Show access matrix for a given resource",
+	Args:    cobra.ExactArgs(1),
+	Long:    `todo`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("resource called")
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(resourceCmd)
+
+	AddRakkessFlags(resourceCmd)
+}

--- a/cmd/resource.go
+++ b/cmd/resource.go
@@ -22,13 +22,43 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const (
+	rakkessSubjectLong = `
+Show all subjects with access to a given resource
+
+This command slices the authorization space (subject, resource, verb)
+along a plane of fixed resource.
+
+Rakkess retrieves all (Cluster)Roles plus their bindings and evaluates the
+authorization for the given resource and verbs. The result is shown as a
+matrix with verbs in the horizontal and subjects in the vertical direction.
+
+Note that the effective access right may differ from the shown results due to
+group membership such as 'system:unauthenticated'.
+
+More on https://github.com/corneliusweig/rakkess/blob/v0.2.1/doc/USAGE.md#usage
+`
+
+	rakkessSubjectExamples = `
+  Review access to deployments in any namespace
+  $ rakkess resource deployments
+
+  Review access deployments in the default namespace (with shorthands)
+  $ rakkess r deploy --namespace default
+
+  Review access for deployments with custom verbs
+  $ rakkess r deploy --verbs get,watch,deletecollection
+`
+)
+
 // resourceCmd represents the resource command
 var resourceCmd = &cobra.Command{
 	Use:     "resource",
-	Aliases: []string{"for", "for-resource"},
-	Short:   "Show access matrix for a given resource",
+	Aliases: []string{"r"},
+	Short:   "Show all subjects with access to a given resource",
 	Args:    cobra.ExactArgs(1),
-	Long:    `todo`,
+	Long:    rakkessSubjectLong,
+	Example: rakkessSubjectExamples,
 	Run: func(cmd *cobra.Command, args []string) {
 		if err := rakkess.RakkessSubject(rakkessOptions, args[0]); err != nil {
 			logrus.Error(err)

--- a/cmd/resource.go
+++ b/cmd/resource.go
@@ -60,7 +60,7 @@ var resourceCmd = &cobra.Command{
 	Long:    rakkessSubjectLong,
 	Example: rakkessSubjectExamples,
 	Run: func(cmd *cobra.Command, args []string) {
-		if err := rakkess.RakkessSubject(rakkessOptions, args[0]); err != nil {
+		if err := rakkess.Subject(rakkessOptions, args[0]); err != nil {
 			logrus.Error(err)
 		}
 	},

--- a/cmd/resource.go
+++ b/cmd/resource.go
@@ -17,7 +17,7 @@ limitations under the License.
 package cmd
 
 import (
-	"github.com/corneliusweig/rakkess/pkg/rakkess/client"
+	"github.com/corneliusweig/rakkess/pkg/rakkess"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -30,8 +30,9 @@ var resourceCmd = &cobra.Command{
 	Args:    cobra.ExactArgs(1),
 	Long:    `todo`,
 	Run: func(cmd *cobra.Command, args []string) {
-		sa, _ := client.GetSubjectAccess(rakkessOptions, args[0])
-		logrus.Infof("%s", sa.Get())
+		if err := rakkess.RakkessSubject(rakkessOptions, args[0]); err != nil {
+			logrus.Error(err)
+		}
 	},
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -73,8 +73,8 @@ var rootCmd = &cobra.Command{
 		ctx, cancel := context.WithCancel(context.Background())
 		catchCtrlC(cancel)
 
-		if err := rakkess.Rakkess(ctx, rakkessOptions); err != nil {
-			logrus.Fatal(err)
+		if err := rakkess.RakkessResource(ctx, rakkessOptions); err != nil {
+			logrus.Error(err)
 		}
 	},
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -71,7 +71,7 @@ var rootCmd = &cobra.Command{
 	Args:    cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx, cancel := context.WithCancel(context.Background())
-		catchCtrC(cancel)
+		catchCtrlC(cancel)
 
 		if err := rakkess.Rakkess(ctx, rakkessOptions); err != nil {
 			logrus.Fatal(err)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -76,7 +76,7 @@ var rootCmd = &cobra.Command{
 		ctx, cancel := context.WithCancel(context.Background())
 		catchCtrlC(cancel)
 
-		if err := rakkess.RakkessResource(ctx, rakkessOptions); err != nil {
+		if err := rakkess.Resource(ctx, rakkessOptions); err != nil {
 			logrus.Error(err)
 		}
 	},

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -68,6 +68,7 @@ var rootCmd = &cobra.Command{
 	Short:   "Review access - show an access matrix for all resources",
 	Long:    rakkessLongDescription,
 	Example: rakkessExamples,
+	Args:    cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx, cancel := context.WithCancel(context.Background())
 		catchCtrC(cancel)
@@ -90,10 +91,7 @@ func Execute() {
 func init() {
 	rootCmd.PersistentFlags().StringVarP(&v, "verbosity", "v", constants.DefaultLogLevel.String(), "Log level (debug, info, warn, error, fatal, panic)")
 
-	rootCmd.Flags().StringSliceVar(&rakkessOptions.Verbs, "verbs", []string{"list", "create", "update", "delete"}, fmt.Sprintf("show access for verbs out of %s", constants.ValidVerbs))
-	rootCmd.Flags().StringVarP(&rakkessOptions.Output, "output", "o", "icon-table", fmt.Sprintf("output format out of %s", constants.ValidOutputFormats))
-
-	rakkessOptions.ConfigFlags.AddFlags(rootCmd.Flags())
+	AddRakkessFlags(rootCmd)
 
 	rootCmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
 		if err := SetUpLogs(rakkessOptions.Streams.ErrOut, v); err != nil {
@@ -101,6 +99,13 @@ func init() {
 		}
 		return nil
 	}
+}
+
+func AddRakkessFlags(cmd *cobra.Command) {
+	cmd.Flags().StringSliceVar(&rakkessOptions.Verbs, "verbs", []string{"list", "create", "update", "delete"}, fmt.Sprintf("show access for verbs out of %s", constants.ValidVerbs))
+	cmd.Flags().StringVarP(&rakkessOptions.Output, "output", "o", "icon-table", fmt.Sprintf("output format out of %s", constants.ValidOutputFormats))
+
+	rakkessOptions.ConfigFlags.AddFlags(cmd.Flags())
 }
 
 func SetUpLogs(out io.Writer, level string) error {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -39,6 +39,9 @@ const (
 	rakkessLongDescription = `
 Show an access matrix for all server resources
 
+This command slices the authorization space (subject, resource, verb)
+along a plane of fixed subject.
+
 Rakkess retrieves the full list of server resources, checks access for
 the current user with the given verbs, and prints the result as a matrix.
 This complements the usual "kubectl auth can-i" command, which works for

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -103,7 +103,7 @@ func init() {
 
 func AddRakkessFlags(cmd *cobra.Command) {
 	cmd.Flags().StringSliceVar(&rakkessOptions.Verbs, "verbs", []string{"list", "create", "update", "delete"}, fmt.Sprintf("show access for verbs out of %s", constants.ValidVerbs))
-	cmd.Flags().StringVarP(&rakkessOptions.Output, "output", "o", "icon-table", fmt.Sprintf("output format out of %s", constants.ValidOutputFormats))
+	cmd.Flags().StringVarP(&rakkessOptions.OutputFormat, "output", "o", "icon-table", fmt.Sprintf("output format out of %s", constants.ValidOutputFormats))
 
 	rakkessOptions.ConfigFlags.AddFlags(cmd.Flags())
 }

--- a/cmd/signals.go
+++ b/cmd/signals.go
@@ -23,7 +23,7 @@ import (
 	"syscall"
 )
 
-func catchCtrC(cancel context.CancelFunc) {
+func catchCtrlC(cancel context.CancelFunc) {
 	catchSigs(cancel, syscall.SIGINT, syscall.SIGPIPE, syscall.SIGTERM)
 }
 

--- a/pkg/rakkess/client/resource_access.go
+++ b/pkg/rakkess/client/resource_access.go
@@ -17,13 +17,11 @@ limitations under the License.
 package client
 
 import (
-	"github.com/corneliusweig/rakkess/pkg/rakkess/constants"
+	"github.com/corneliusweig/rakkess/pkg/rakkess/client/result"
 	"github.com/corneliusweig/rakkess/pkg/rakkess/options"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/sets"
 	clientv1 "k8s.io/client-go/kubernetes/typed/rbac/v1"
 )
 
@@ -37,30 +35,13 @@ const (
 	roleName        = "Role"
 )
 
-// roleRef uniquely identifies a ClusterRole or namespaced Role. The namespace
-// is always fixed and need not be part of roleRef to identify a namespaced Role.
-type roleRef struct {
-	Name, Kind string
-}
-
-// SubjectRef uniquely identifies the subject of a RoleBinding or ClusterRoleBinding
-type SubjectRef struct {
-	Name, Kind string
-}
-
-type SubjectAccess struct {
-	Resource      string
-	roles         map[roleRef]sets.String
-	subjectAccess map[SubjectRef]sets.String
-}
-
-func GetSubjectAccess(opts *options.RakkessOptions, resource string) (*SubjectAccess, error) {
+func GetSubjectAccess(opts *options.RakkessOptions, resource string) (*result.SubjectAccess, error) {
 	rbacClient, err := getRbacClient(opts)
 	if err != nil {
 		return nil, err
 	}
 
-	sa := newSubjectAccess(resource)
+	sa := result.NewSubjectAccess(resource)
 
 	if err := fetchMatchingClusterRoles(rbacClient, sa); err != nil {
 		logrus.Warnf("ClusterRoles could not be fetched (%s): result will be incomplete", err)
@@ -79,7 +60,7 @@ func GetSubjectAccess(opts *options.RakkessOptions, resource string) (*SubjectAc
 	return sa, nil
 }
 
-func resolveRoleBindings(rbacClient clientv1.RoleBindingsGetter, sa *SubjectAccess, namespace *string) error {
+func resolveRoleBindings(rbacClient clientv1.RoleBindingsGetter, sa *result.SubjectAccess, namespace *string) error {
 	if namespace == nil || *namespace == "" {
 		logrus.Debugf("Skipping role resolution because namespace not set")
 		return nil
@@ -91,32 +72,32 @@ func resolveRoleBindings(rbacClient clientv1.RoleBindingsGetter, sa *SubjectAcce
 		return err
 	}
 	for _, rb := range roleBindings.Items {
-		r := roleRef{
+		r := result.RoleRef{
 			Name: rb.RoleRef.Name,
 			Kind: rb.RoleRef.Kind,
 		}
-		sa.resolveRoleRef(r, rb.Subjects)
+		sa.ResolveRoleRef(r, rb.Subjects)
 	}
 	return nil
 }
 
-func resolveClusterRoleBindings(rbacClient clientv1.ClusterRoleBindingsGetter, sa *SubjectAccess) error {
+func resolveClusterRoleBindings(rbacClient clientv1.ClusterRoleBindingsGetter, sa *result.SubjectAccess) error {
 	logrus.Debugf("fetching ClusterRoleBindings")
 	clusterRoleBindings, err := rbacClient.ClusterRoleBindings().List(metav1.ListOptions{})
 	if err != nil {
 		return err
 	}
 	for _, crb := range clusterRoleBindings.Items {
-		r := roleRef{
+		r := result.RoleRef{
 			Name: crb.RoleRef.Name,
 			Kind: crb.RoleRef.Kind,
 		}
-		sa.resolveRoleRef(r, crb.Subjects)
+		sa.ResolveRoleRef(r, crb.Subjects)
 	}
 	return nil
 }
 
-func fetchMatchingClusterRoles(rbacClient clientv1.ClusterRolesGetter, sa *SubjectAccess) error {
+func fetchMatchingClusterRoles(rbacClient clientv1.ClusterRolesGetter, sa *result.SubjectAccess) error {
 	logrus.Debugf("fetching clusterRoles")
 	roleList, err := rbacClient.ClusterRoles().List(metav1.ListOptions{})
 	if err != nil {
@@ -125,18 +106,18 @@ func fetchMatchingClusterRoles(rbacClient clientv1.ClusterRolesGetter, sa *Subje
 	logrus.Tracef("roles: %s", roleList)
 
 	for _, role := range roleList.Items {
-		r := roleRef{
+		r := result.RoleRef{
 			Name: role.Name,
 			Kind: clusterRoleName,
 		}
 		for _, rule := range role.Rules {
-			sa.matchRules(r, rule)
+			sa.MatchRules(r, rule)
 		}
 	}
 	return nil
 }
 
-func fetchMatchingRoles(rbacClient clientv1.RolesGetter, sa *SubjectAccess, namespace *string) error {
+func fetchMatchingRoles(rbacClient clientv1.RolesGetter, sa *result.SubjectAccess, namespace *string) error {
 	if namespace == nil || *namespace == "" {
 		logrus.Debugf("Skipping role fetching because namespace not set")
 		return nil
@@ -149,67 +130,15 @@ func fetchMatchingRoles(rbacClient clientv1.RolesGetter, sa *SubjectAccess, name
 	}
 
 	for _, role := range roleList.Items {
-		r := roleRef{
+		r := result.RoleRef{
 			Name: role.Name,
 			Kind: roleName,
 		}
 		for _, rule := range role.Rules {
-			sa.matchRules(r, rule)
+			sa.MatchRules(r, rule)
 		}
 	}
 	return nil
-}
-
-func newSubjectAccess(resource string) *SubjectAccess {
-	return &SubjectAccess{
-		Resource:      resource,
-		roles:         make(map[roleRef]sets.String),
-		subjectAccess: make(map[SubjectRef]sets.String),
-	}
-}
-
-func (sa *SubjectAccess) Get() map[SubjectRef]sets.String {
-	return sa.subjectAccess
-}
-
-func (sa *SubjectAccess) resolveRoleRef(r roleRef, subjects []rbacv1.Subject) {
-	verbsForRole, ok := sa.roles[r]
-	if !ok {
-		return
-	}
-	for _, subject := range subjects {
-		s := SubjectRef{
-			Name: subject.Name,
-			Kind: subject.Kind,
-		}
-		if verbs, ok := sa.subjectAccess[s]; ok {
-			sa.subjectAccess[s] = verbs.Union(verbsForRole)
-		} else {
-			sa.subjectAccess[s] = verbsForRole
-		}
-	}
-}
-
-func (sa *SubjectAccess) matchRules(r roleRef, rule rbacv1.PolicyRule) {
-	for _, resource := range rule.Resources {
-		if resource == rbacv1.ResourceAll || resource == sa.Resource {
-			expandedVerbs := expandVerbs(rule.Verbs)
-			if verbs, ok := sa.roles[r]; ok {
-				sa.roles[r] = sets.NewString(expandedVerbs...).Union(verbs)
-			} else {
-				sa.roles[r] = sets.NewString(expandedVerbs...)
-			}
-		}
-	}
-}
-
-func expandVerbs(verbs []string) []string {
-	for _, verb := range verbs {
-		if verb == rbacv1.VerbAll {
-			return constants.ValidVerbs
-		}
-	}
-	return verbs
 }
 
 func GetRbacClient(o *options.RakkessOptions) (clientv1.RbacV1Interface, error) {

--- a/pkg/rakkess/client/resource_access.go
+++ b/pkg/rakkess/client/resource_access.go
@@ -1,0 +1,222 @@
+/*
+Copyright 2019 Cornelius Weig
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"github.com/corneliusweig/rakkess/pkg/rakkess/constants"
+	"github.com/corneliusweig/rakkess/pkg/rakkess/options"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	clientv1 "k8s.io/client-go/kubernetes/typed/rbac/v1"
+)
+
+var (
+	// for testing
+	getRbacClient = GetRbacClient
+)
+
+const (
+	clusterRoleName = "ClusterRole"
+	roleName        = "Role"
+)
+
+// roleRef uniquely identifies a ClusterRole or namespaced Role. The namespace
+// is always fixed and need not be part of roleRef to identify a namespaced Role.
+type roleRef struct {
+	Name, Kind string
+}
+
+// SubjectRef uniquely identifies the subject of a RoleBinding or ClusterRoleBinding
+type SubjectRef struct {
+	Name, Kind string
+}
+
+type SubjectAccess struct {
+	Resource      string
+	roles         map[roleRef]sets.String
+	subjectAccess map[SubjectRef]sets.String
+}
+
+func GetSubjectAccess(opts *options.RakkessOptions, resource string) (*SubjectAccess, error) {
+	rbacClient, err := getRbacClient(opts)
+	if err != nil {
+		return nil, err
+	}
+
+	sa := newSubjectAccess(resource)
+
+	if err := fetchMatchingClusterRoles(rbacClient, sa); err != nil {
+		logrus.Warnf("ClusterRoles could not be fetched (%s): result will be incomplete", err)
+	} else if err := resolveClusterRoleBindings(rbacClient, sa); err != nil {
+		logrus.Warnf("ClusterRolesBindings could not be fetched (%s): result will be incomplete", err)
+	}
+
+	namespace := opts.ConfigFlags.Namespace
+	if err := fetchMatchingRoles(rbacClient, sa, namespace); err != nil {
+		return nil, errors.Wrapf(err, "fetching Roles failed")
+	}
+	if err := resolveRoleBindings(rbacClient, sa, namespace); err != nil {
+		return nil, errors.Wrapf(err, "fetching RoleBindings failed")
+	}
+
+	return sa, nil
+}
+
+func resolveRoleBindings(rbacClient clientv1.RoleBindingsGetter, sa *SubjectAccess, namespace *string) error {
+	if namespace == nil || *namespace == "" {
+		logrus.Debugf("Skipping role resolution because namespace not set")
+		return nil
+	}
+
+	logrus.Debugf("fetching RoleBindings for namespace %s", *namespace)
+	roleBindings, err := rbacClient.RoleBindings(*namespace).List(metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+	for _, rb := range roleBindings.Items {
+		r := roleRef{
+			Name: rb.RoleRef.Name,
+			Kind: rb.RoleRef.Kind,
+		}
+		sa.resolveRoleRef(r, rb.Subjects)
+	}
+	return nil
+}
+
+func resolveClusterRoleBindings(rbacClient clientv1.ClusterRoleBindingsGetter, sa *SubjectAccess) error {
+	logrus.Debugf("fetching ClusterRoleBindings")
+	clusterRoleBindings, err := rbacClient.ClusterRoleBindings().List(metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+	for _, crb := range clusterRoleBindings.Items {
+		r := roleRef{
+			Name: crb.RoleRef.Name,
+			Kind: crb.RoleRef.Kind,
+		}
+		sa.resolveRoleRef(r, crb.Subjects)
+	}
+	return nil
+}
+
+func fetchMatchingClusterRoles(rbacClient clientv1.ClusterRolesGetter, sa *SubjectAccess) error {
+	logrus.Debugf("fetching clusterRoles")
+	roleList, err := rbacClient.ClusterRoles().List(metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+	logrus.Tracef("roles: %s", roleList)
+
+	for _, role := range roleList.Items {
+		r := roleRef{
+			Name: role.Name,
+			Kind: clusterRoleName,
+		}
+		for _, rule := range role.Rules {
+			sa.matchRules(r, rule)
+		}
+	}
+	return nil
+}
+
+func fetchMatchingRoles(rbacClient clientv1.RolesGetter, sa *SubjectAccess, namespace *string) error {
+	if namespace == nil || *namespace == "" {
+		logrus.Debugf("Skipping role fetching because namespace not set")
+		return nil
+	}
+
+	logrus.Debugf("fetching roles for namespace %s", *namespace)
+	roleList, err := rbacClient.Roles(*namespace).List(metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+
+	for _, role := range roleList.Items {
+		r := roleRef{
+			Name: role.Name,
+			Kind: roleName,
+		}
+		for _, rule := range role.Rules {
+			sa.matchRules(r, rule)
+		}
+	}
+	return nil
+}
+
+func newSubjectAccess(resource string) *SubjectAccess {
+	return &SubjectAccess{
+		Resource:      resource,
+		roles:         make(map[roleRef]sets.String),
+		subjectAccess: make(map[SubjectRef]sets.String),
+	}
+}
+
+func (sa *SubjectAccess) Get() map[SubjectRef]sets.String {
+	return sa.subjectAccess
+}
+
+func (sa *SubjectAccess) resolveRoleRef(r roleRef, subjects []rbacv1.Subject) {
+	verbsForRole, ok := sa.roles[r]
+	if !ok {
+		return
+	}
+	for _, subject := range subjects {
+		s := SubjectRef{
+			Name: subject.Name,
+			Kind: subject.Kind,
+		}
+		if verbs, ok := sa.subjectAccess[s]; ok {
+			sa.subjectAccess[s] = verbs.Union(verbsForRole)
+		} else {
+			sa.subjectAccess[s] = verbsForRole
+		}
+	}
+}
+
+func (sa *SubjectAccess) matchRules(r roleRef, rule rbacv1.PolicyRule) {
+	for _, resource := range rule.Resources {
+		if resource == rbacv1.ResourceAll || resource == sa.Resource {
+			expandedVerbs := expandVerbs(rule.Verbs)
+			if verbs, ok := sa.roles[r]; ok {
+				sa.roles[r] = sets.NewString(expandedVerbs...).Union(verbs)
+			} else {
+				sa.roles[r] = sets.NewString(expandedVerbs...)
+			}
+		}
+	}
+}
+
+func expandVerbs(verbs []string) []string {
+	for _, verb := range verbs {
+		if verb == rbacv1.VerbAll {
+			return constants.ValidVerbs
+		}
+	}
+	return verbs
+}
+
+func GetRbacClient(o *options.RakkessOptions) (clientv1.RbacV1Interface, error) {
+	restConfig, err := o.ConfigFlags.ToRESTConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	return clientv1.NewForConfigOrDie(restConfig), nil
+}

--- a/pkg/rakkess/client/resource_access_test.go
+++ b/pkg/rakkess/client/resource_access_test.go
@@ -17,9 +17,10 @@ limitations under the License.
 package client
 
 import (
-	"github.com/corneliusweig/rakkess/pkg/rakkess/constants"
 	"testing"
 
+	"github.com/corneliusweig/rakkess/pkg/rakkess/client/result"
+	"github.com/corneliusweig/rakkess/pkg/rakkess/constants"
 	"github.com/corneliusweig/rakkess/pkg/rakkess/options"
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/rbac/v1"
@@ -41,7 +42,7 @@ func TestGetSubjectAccess(t *testing.T) {
 		clusterRoleBindings []v1.ClusterRoleBinding
 		roles               []v1.Role
 		roleBindings        []v1.RoleBinding
-		expected            map[SubjectRef]sets.String
+		expected            map[result.SubjectRef]sets.String
 	}{
 		{
 			name:                "cluster-role and role matches",
@@ -51,7 +52,7 @@ func TestGetSubjectAccess(t *testing.T) {
 			clusterRoleBindings: clusterRoleBindings("clusterrole-1", "test-user"),
 			roles:               roles("role-1", "some-ns", "deployments", "list"),
 			roleBindings:        roleBindings("role-1", "Role", "test-user"),
-			expected: map[SubjectRef]sets.String{
+			expected: map[result.SubjectRef]sets.String{
 				{Name: "test-user", Kind: "User"}: sets.NewString("create", "list"),
 			},
 		},
@@ -63,7 +64,7 @@ func TestGetSubjectAccess(t *testing.T) {
 			clusterRoleBindings: clusterRoleBindings("clusterrole-1", "user1", "user2"),
 			roles:               roles("role-1", "some-ns", "deployments", "list"),
 			roleBindings:        roleBindings("role-1", "Role", "user2", "user3"),
-			expected: map[SubjectRef]sets.String{
+			expected: map[result.SubjectRef]sets.String{
 				{Name: "user1", Kind: "User"}: sets.NewString("create"),
 				{Name: "user2", Kind: "User"}: sets.NewString("create", "list"),
 				{Name: "user3", Kind: "User"}: sets.NewString("list"),
@@ -77,7 +78,7 @@ func TestGetSubjectAccess(t *testing.T) {
 			clusterRoleBindings: clusterRoleBindings("clusterrole-1", "test-user"),
 			roles:               roles("role-1", "some-ns", "deployments", "list"),
 			roleBindings:        roleBindings("role-1", "Role", "test-user"),
-			expected: map[SubjectRef]sets.String{
+			expected: map[result.SubjectRef]sets.String{
 				{Name: "test-user", Kind: "User"}: sets.NewString("create"),
 			},
 		},
@@ -87,7 +88,7 @@ func TestGetSubjectAccess(t *testing.T) {
 			resource:     "deployments",
 			clusterRoles: clusterRoles("clusterrole-1", "deployments", "create"),
 			roleBindings: roleBindings("clusterrole-1", "ClusterRole", "test-user"),
-			expected: map[SubjectRef]sets.String{
+			expected: map[result.SubjectRef]sets.String{
 				{Name: "test-user", Kind: "User"}: sets.NewString("create"),
 			},
 		},
@@ -99,7 +100,7 @@ func TestGetSubjectAccess(t *testing.T) {
 			clusterRoleBindings: clusterRoleBindings("clusterrole-1", "test-user"),
 			roles:               roles("role-1", "some-ns", "configmaps", "list"),
 			roleBindings:        roleBindings("role-1", "Role", "test-user"),
-			expected:            map[SubjectRef]sets.String{},
+			expected:            map[result.SubjectRef]sets.String{},
 		},
 		{
 			name:                "VerbAll role binding",
@@ -109,7 +110,7 @@ func TestGetSubjectAccess(t *testing.T) {
 			clusterRoleBindings: clusterRoleBindings("clusterrole-1", "test-user"),
 			roles:               roles("role-1", "some-ns", "configmaps", v1.VerbAll),
 			roleBindings:        roleBindings("role-1", "Role", "test-user"),
-			expected: map[SubjectRef]sets.String{
+			expected: map[result.SubjectRef]sets.String{
 				{Name: "test-user", Kind: "User"}: sets.NewString(constants.ValidVerbs...),
 			},
 		},
@@ -119,7 +120,7 @@ func TestGetSubjectAccess(t *testing.T) {
 			resource:            "configmaps",
 			clusterRoles:        clusterRoles("clusterrole-1", "configmaps", v1.VerbAll),
 			clusterRoleBindings: clusterRoleBindings("clusterrole-1", "test-user"),
-			expected: map[SubjectRef]sets.String{
+			expected: map[result.SubjectRef]sets.String{
 				{Name: "test-user", Kind: "User"}: sets.NewString(constants.ValidVerbs...),
 			},
 		},

--- a/pkg/rakkess/client/resource_access_test.go
+++ b/pkg/rakkess/client/resource_access_test.go
@@ -1,0 +1,236 @@
+/*
+Copyright 2019 Cornelius Weig
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"github.com/corneliusweig/rakkess/pkg/rakkess/constants"
+	"testing"
+
+	"github.com/corneliusweig/rakkess/pkg/rakkess/options"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	clientv1 "k8s.io/client-go/kubernetes/typed/rbac/v1"
+	"k8s.io/client-go/kubernetes/typed/rbac/v1/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+func TestGetSubjectAccess(t *testing.T) {
+	tests := []struct {
+		name                string
+		namespace           string
+		resource            string
+		clusterRoles        []v1.ClusterRole
+		clusterRoleBindings []v1.ClusterRoleBinding
+		roles               []v1.Role
+		roleBindings        []v1.RoleBinding
+		expected            map[SubjectRef]sets.String
+	}{
+		{
+			name:                "cluster-role and role matches",
+			namespace:           "some-ns",
+			resource:            "deployments",
+			clusterRoles:        clusterRoles("clusterrole-1", "deployments", "create"),
+			clusterRoleBindings: clusterRoleBindings("clusterrole-1", "test-user"),
+			roles:               roles("role-1", "some-ns", "deployments", "list"),
+			roleBindings:        roleBindings("role-1", "Role", "test-user"),
+			expected: map[SubjectRef]sets.String{
+				{Name: "test-user", Kind: "User"}: sets.NewString("create", "list"),
+			},
+		},
+		{
+			name:                "cluster-role and role matches, multiple subjects",
+			namespace:           "some-ns",
+			resource:            "deployments",
+			clusterRoles:        clusterRoles("clusterrole-1", "deployments", "create"),
+			clusterRoleBindings: clusterRoleBindings("clusterrole-1", "user1", "user2"),
+			roles:               roles("role-1", "some-ns", "deployments", "list"),
+			roleBindings:        roleBindings("role-1", "Role", "user2", "user3"),
+			expected: map[SubjectRef]sets.String{
+				{Name: "user1", Kind: "User"}: sets.NewString("create"),
+				{Name: "user2", Kind: "User"}: sets.NewString("create", "list"),
+				{Name: "user3", Kind: "User"}: sets.NewString("list"),
+			},
+		},
+		{
+			name:                "cluster-role and role matches, global scope",
+			namespace:           "", // empty namespace means global scope
+			resource:            "deployments",
+			clusterRoles:        clusterRoles("clusterrole-1", "deployments", "create"),
+			clusterRoleBindings: clusterRoleBindings("clusterrole-1", "test-user"),
+			roles:               roles("role-1", "some-ns", "deployments", "list"),
+			roleBindings:        roleBindings("role-1", "Role", "test-user"),
+			expected: map[SubjectRef]sets.String{
+				{Name: "test-user", Kind: "User"}: sets.NewString("create"),
+			},
+		},
+		{
+			name:         "rolebinding to clusterrole",
+			namespace:    "some-ns",
+			resource:     "deployments",
+			clusterRoles: clusterRoles("clusterrole-1", "deployments", "create"),
+			roleBindings: roleBindings("clusterrole-1", "ClusterRole", "test-user"),
+			expected: map[SubjectRef]sets.String{
+				{Name: "test-user", Kind: "User"}: sets.NewString("create"),
+			},
+		},
+		{
+			name:                "bindings for wrong resource",
+			namespace:           "some-ns",
+			resource:            "deployments",
+			clusterRoles:        clusterRoles("clusterrole-1", "configmaps", "create"),
+			clusterRoleBindings: clusterRoleBindings("clusterrole-1", "test-user"),
+			roles:               roles("role-1", "some-ns", "configmaps", "list"),
+			roleBindings:        roleBindings("role-1", "Role", "test-user"),
+			expected:            map[SubjectRef]sets.String{},
+		},
+		{
+			name:                "VerbAll role binding",
+			namespace:           "some-ns",
+			resource:            "configmaps",
+			clusterRoles:        clusterRoles("clusterrole-1", "configmaps", "create"),
+			clusterRoleBindings: clusterRoleBindings("clusterrole-1", "test-user"),
+			roles:               roles("role-1", "some-ns", "configmaps", v1.VerbAll),
+			roleBindings:        roleBindings("role-1", "Role", "test-user"),
+			expected: map[SubjectRef]sets.String{
+				{Name: "test-user", Kind: "User"}: sets.NewString(constants.ValidVerbs...),
+			},
+		},
+		{
+			name:                "VerbAll clusterrole binding",
+			namespace:           "some-ns",
+			resource:            "configmaps",
+			clusterRoles:        clusterRoles("clusterrole-1", "configmaps", v1.VerbAll),
+			clusterRoleBindings: clusterRoleBindings("clusterrole-1", "test-user"),
+			expected: map[SubjectRef]sets.String{
+				{Name: "test-user", Kind: "User"}: sets.NewString(constants.ValidVerbs...),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+
+			fakeRbacClient := &fake.FakeRbacV1{Fake: &k8stesting.Fake{}}
+			fakeRbacClient.Fake.AddReactor("list", "roles",
+				func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+					return true, &v1.RoleList{Items: test.roles}, nil
+				})
+			fakeRbacClient.Fake.AddReactor("list", "rolebindings",
+				func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+					return true, &v1.RoleBindingList{Items: test.roleBindings}, nil
+				})
+			fakeRbacClient.Fake.AddReactor("list", "clusterroles",
+				func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+					return true, &v1.ClusterRoleList{Items: test.clusterRoles}, nil
+				})
+			fakeRbacClient.Fake.AddReactor("list", "clusterrolebindings",
+				func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+					return true, &v1.ClusterRoleBindingList{Items: test.clusterRoleBindings}, nil
+				})
+
+			getRbacClient = func(*options.RakkessOptions) (clientv1.RbacV1Interface, error) {
+				return fakeRbacClient, nil
+			}
+			defer func() { getRbacClient = GetRbacClient }()
+
+			opts := &options.RakkessOptions{
+				ConfigFlags: &genericclioptions.ConfigFlags{
+					Namespace: &test.namespace,
+				},
+			}
+			sa, err := GetSubjectAccess(opts, test.resource)
+			assert.NoError(t, err)
+			assert.Equal(t, test.resource, sa.Resource)
+			assert.Equal(t, test.expected, sa.Get())
+		})
+	}
+}
+
+func clusterRoles(name, resource string, verbs ...string) []v1.ClusterRole {
+	return []v1.ClusterRole{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: name,
+			},
+			Rules: []v1.PolicyRule{
+				{
+					Verbs:     verbs,
+					Resources: []string{resource},
+				},
+			},
+		},
+	}
+}
+
+func clusterRoleBindings(clusterRole string, subjects ...string) []v1.ClusterRoleBinding {
+	ss := make([]v1.Subject, 0, len(subjects))
+	for _, s := range subjects {
+		ss = append(ss, v1.Subject{
+			Kind: "User",
+			Name: s,
+		})
+	}
+	return []v1.ClusterRoleBinding{
+		{
+			Subjects: ss,
+			RoleRef: v1.RoleRef{
+				Name: clusterRole,
+				Kind: "ClusterRole",
+			},
+		},
+	}
+}
+
+func roles(name, namespace, resource string, verbs ...string) []v1.Role {
+	return []v1.Role{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+			Rules: []v1.PolicyRule{
+				{
+					Verbs:     verbs,
+					Resources: []string{resource},
+				},
+			},
+		},
+	}
+}
+
+func roleBindings(role, kind string, subjects ...string) []v1.RoleBinding {
+	ss := make([]v1.Subject, 0, len(subjects))
+	for _, s := range subjects {
+		ss = append(ss, v1.Subject{
+			Kind: "User",
+			Name: s,
+		})
+	}
+	return []v1.RoleBinding{
+		{
+			Subjects: ss,
+			RoleRef: v1.RoleRef{
+				Name: role,
+				Kind: kind,
+			},
+		},
+	}
+}

--- a/pkg/rakkess/client/result/resource.go
+++ b/pkg/rakkess/client/result/resource.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2019 Cornelius Weig
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package result
+
+import (
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+)
+
+type CodeConverter func(int) string
+type MatrixPrinter interface {
+	Print(w io.Writer, converter CodeConverter, requestedVerbs []string)
+}
+
+type ResourceAccessItem struct {
+	Name   string
+	Access map[string]int
+	Err    []error
+}
+
+type ResourceAccess []ResourceAccessItem
+
+func NewResourceAccess(items []ResourceAccessItem) ResourceAccess {
+	ra := ResourceAccess(items)
+	sort.Stable(ra)
+	return ra
+}
+
+func (ra ResourceAccess) Len() int      { return len(ra) }
+func (ra ResourceAccess) Swap(i, j int) { ra[i], ra[j] = ra[j], ra[i] }
+func (ra ResourceAccess) Less(i, j int) bool {
+	ret := strings.Compare(ra[i].Name, ra[j].Name)
+	if ret > 0 {
+		return false
+	} else if ret == 0 {
+		return i < j
+	}
+	return true
+}
+
+func (ra ResourceAccess) Print(w io.Writer, converter CodeConverter, requestedVerbs []string) {
+	// table header
+	fmt.Fprint(w, "NAME")
+	for _, v := range requestedVerbs {
+		fmt.Fprintf(w, "\t%s", strings.ToUpper(v))
+	}
+	fmt.Fprint(w, "\n")
+
+	// table body
+	for _, r := range ra {
+		fmt.Fprintf(w, "%s", r.Name)
+		for _, v := range requestedVerbs {
+			fmt.Fprintf(w, "\t%s", converter(r.Access[v]))
+		}
+		fmt.Fprint(w, "\n")
+	}
+}

--- a/pkg/rakkess/client/result/resource.go
+++ b/pkg/rakkess/client/result/resource.go
@@ -23,11 +23,6 @@ import (
 	"strings"
 )
 
-type CodeConverter func(int) string
-type MatrixPrinter interface {
-	Print(w io.Writer, converter CodeConverter, requestedVerbs []string)
-}
-
 type ResourceAccessItem struct {
 	Name   string
 	Access map[string]int

--- a/pkg/rakkess/client/result/resource_test.go
+++ b/pkg/rakkess/client/result/resource_test.go
@@ -119,7 +119,7 @@ func TestResourceAccess_Print(t *testing.T) {
 				},
 			},
 			verbs:    []string{"list"},
-			expected: "NAME\tLIST\nresource1no\nresource2\tno\nresource3\tyes\n",
+			expected: "NAME\tLIST\nresource1\tno\nresource2\tno\nresource3\tyes\n",
 		},
 	}
 

--- a/pkg/rakkess/client/result/resource_test.go
+++ b/pkg/rakkess/client/result/resource_test.go
@@ -1,0 +1,134 @@
+/*
+Copyright 2019 Cornelius Weig
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package result
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSortResult(t *testing.T) {
+	makeResult := func(key string, value int) map[string]int {
+		result := make(map[string]int)
+		result[key] = value
+		return result
+	}
+	tests := []struct {
+		name   string
+		input  []ResourceAccessItem
+		sorted []ResourceAccessItem
+	}{
+		{
+			name:   "two inputs",
+			input:  []ResourceAccessItem{{Name: "b second"}, {Name: "a first"}},
+			sorted: []ResourceAccessItem{{Name: "a first"}, {Name: "b second"}},
+		},
+		{
+			name:   "three inputs",
+			input:  []ResourceAccessItem{{Name: "b second"}, {Name: "c third"}, {Name: "a first"}},
+			sorted: []ResourceAccessItem{{Name: "a first"}, {Name: "b second"}, {Name: "c third"}},
+		},
+		{
+			name: "three inputs, stable",
+			input: []ResourceAccessItem{
+				{Name: "same", Access: makeResult("b", 1)},
+				{Name: "same", Access: makeResult("a", 2)},
+				{Name: "same", Access: makeResult("c", 3)},
+			},
+			sorted: []ResourceAccessItem{
+				{Name: "same", Access: makeResult("b", 1)},
+				{Name: "same", Access: makeResult("a", 2)},
+				{Name: "same", Access: makeResult("c", 3)},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual := NewResourceAccess(test.input)
+			assert.Equal(t, test.sorted, []ResourceAccessItem(actual))
+		})
+	}
+}
+
+func TestResourceAccess_Print(t *testing.T) {
+	evenYesOddNo := func(i int) string {
+		if i%2 == 0 {
+			return "yes"
+		}
+		return "no"
+	}
+	tests := []struct {
+		name     string
+		items    ResourceAccess
+		verbs    []string
+		expected string
+	}{
+		{
+			name: "single row with multiple verbs",
+			items: []ResourceAccessItem{
+				{
+					Name:   "resource1",
+					Access: map[string]int{"list": 1, "get": 2, "delete": 3},
+				},
+			},
+			verbs:    []string{"list", "get", "delete"},
+			expected: "NAME\tLIST\tGET\tDELETE\nresource1\tno\tyes\tno\n",
+		},
+		{
+			name: "single row with ignored verbs",
+			items: []ResourceAccessItem{
+				{
+					Name:   "resource1",
+					Access: map[string]int{"list": 1, "get": 2, "delete": 3},
+				},
+			},
+			verbs:    []string{"list"},
+			expected: "NAME\tLIST\nresource1\tno\n",
+		},
+		{
+			name: "multiple rows",
+			items: []ResourceAccessItem{
+				{
+					Name:   "resource1",
+					Access: map[string]int{"list": 1},
+				},
+				{
+					Name:   "resource2",
+					Access: map[string]int{"list": 1},
+				},
+				{
+					Name:   "resource3",
+					Access: map[string]int{"list": 2},
+				},
+			},
+			verbs:    []string{"list"},
+			expected: "NAME\tLIST\nresource1no\nresource2\tno\nresource3\tyes\n",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			buf := &bytes.Buffer{}
+			test.items.Print(buf, evenYesOddNo, test.verbs)
+
+			assert.Equal(t, test.expected, buf.String())
+		})
+	}
+}

--- a/pkg/rakkess/client/result/result.go
+++ b/pkg/rakkess/client/result/result.go
@@ -1,0 +1,28 @@
+/*
+Copyright 2019 Cornelius Weig
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package result
+
+import "io"
+
+// CodeConverter converts an access code to a human-readable string.
+type CodeConverter func(int) string
+
+// MatrixPrinter needs to be implemented by result types.
+type MatrixPrinter interface {
+	// Print writes the result for the requestedVerbs to w using the code converter.
+	Print(w io.Writer, converter CodeConverter, requestedVerbs []string)
+}

--- a/pkg/rakkess/client/result/result.go
+++ b/pkg/rakkess/client/result/result.go
@@ -18,6 +18,13 @@ package result
 
 import "io"
 
+const (
+	AccessAllowed = iota
+	AccessDenied
+	AccessNotApplicable
+	AccessRequestErr
+)
+
 // CodeConverter converts an access code to a human-readable string.
 type CodeConverter func(int) string
 

--- a/pkg/rakkess/client/result/subject.go
+++ b/pkg/rakkess/client/result/subject.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2019 Cornelius Weig
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package result
+
+import (
+	"github.com/corneliusweig/rakkess/pkg/rakkess/constants"
+	v1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+// RoleRef uniquely identifies a ClusterRole or namespaced Role. The namespace
+// is always fixed and need not be part of RoleRef to identify a namespaced Role.
+type RoleRef struct {
+	Name, Kind string
+}
+
+// SubjectRef uniquely identifies the subject of a RoleBinding or ClusterRoleBinding
+type SubjectRef struct {
+	Name, Kind string
+}
+
+type SubjectAccess struct {
+	Resource      string
+	roles         map[RoleRef]sets.String
+	subjectAccess map[SubjectRef]sets.String
+}
+
+func NewSubjectAccess(resource string) *SubjectAccess {
+	return &SubjectAccess{
+		Resource:      resource,
+		roles:         make(map[RoleRef]sets.String),
+		subjectAccess: make(map[SubjectRef]sets.String),
+	}
+}
+
+func (sa *SubjectAccess) Get() map[SubjectRef]sets.String {
+	return sa.subjectAccess
+}
+
+func (sa *SubjectAccess) ResolveRoleRef(r RoleRef, subjects []v1.Subject) {
+	verbsForRole, ok := sa.roles[r]
+	if !ok {
+		return
+	}
+	for _, subject := range subjects {
+		s := SubjectRef{
+			Name: subject.Name,
+			Kind: subject.Kind,
+		}
+		if verbs, ok := sa.subjectAccess[s]; ok {
+			sa.subjectAccess[s] = verbs.Union(verbsForRole)
+		} else {
+			sa.subjectAccess[s] = verbsForRole
+		}
+	}
+}
+
+func (sa *SubjectAccess) MatchRules(r RoleRef, rule v1.PolicyRule) {
+	for _, resource := range rule.Resources {
+		if resource == v1.ResourceAll || resource == sa.Resource {
+			expandedVerbs := expandVerbs(rule.Verbs)
+			if verbs, ok := sa.roles[r]; ok {
+				sa.roles[r] = sets.NewString(expandedVerbs...).Union(verbs)
+			} else {
+				sa.roles[r] = sets.NewString(expandedVerbs...)
+			}
+		}
+	}
+}
+
+func expandVerbs(verbs []string) []string {
+	for _, verb := range verbs {
+		if verb == v1.VerbAll {
+			return constants.ValidVerbs
+		}
+	}
+	return verbs
+}

--- a/pkg/rakkess/client/result/subject.go
+++ b/pkg/rakkess/client/result/subject.go
@@ -97,7 +97,7 @@ func expandVerbs(verbs []string) []string {
 	return verbs
 }
 
-func (ra *SubjectAccess) Print(w io.Writer, converter CodeConverter, requestedVerbs []string) {
+func (sa *SubjectAccess) Print(w io.Writer, converter CodeConverter, requestedVerbs []string) {
 	// table header
 	fmt.Fprint(w, "NAME\tKIND\tSA-NAMESPACE")
 	for _, v := range requestedVerbs {
@@ -105,15 +105,15 @@ func (ra *SubjectAccess) Print(w io.Writer, converter CodeConverter, requestedVe
 	}
 	fmt.Fprint(w, "\n")
 
-	subjects := make([]SubjectRef, 0, len(ra.subjectAccess))
-	for s, _ := range ra.subjectAccess {
+	subjects := make([]SubjectRef, 0, len(sa.subjectAccess))
+	for s := range sa.subjectAccess {
 		subjects = append(subjects, s)
 	}
 	sort.Stable(sortableSubjects(subjects))
 
 	// table body
 	for _, subject := range subjects {
-		verbs := ra.subjectAccess[subject]
+		verbs := sa.subjectAccess[subject]
 		if !verbs.HasAny(requestedVerbs...) {
 			continue
 		}

--- a/pkg/rakkess/client/result/subject.go
+++ b/pkg/rakkess/client/result/subject.go
@@ -35,7 +35,7 @@ type RoleRef struct {
 
 // SubjectRef uniquely identifies the subject of a RoleBinding or ClusterRoleBinding
 type SubjectRef struct {
-	Name, Kind string
+	Name, Kind, Namespace string
 }
 
 type SubjectAccess struct {
@@ -63,8 +63,9 @@ func (sa *SubjectAccess) ResolveRoleRef(r RoleRef, subjects []v1.Subject) {
 	}
 	for _, subject := range subjects {
 		s := SubjectRef{
-			Name: subject.Name,
-			Kind: subject.Kind,
+			Name:      subject.Name,
+			Kind:      subject.Kind,
+			Namespace: subject.Namespace,
 		}
 		if verbs, ok := sa.subjectAccess[s]; ok {
 			sa.subjectAccess[s] = verbs.Union(verbsForRole)
@@ -98,7 +99,7 @@ func expandVerbs(verbs []string) []string {
 
 func (ra *SubjectAccess) Print(w io.Writer, converter CodeConverter, requestedVerbs []string) {
 	// table header
-	fmt.Fprint(w, "NAME\tKIND")
+	fmt.Fprint(w, "NAME\tKIND\tSA-NAMESPACE")
 	for _, v := range requestedVerbs {
 		fmt.Fprintf(w, "\t%s", strings.ToUpper(v))
 	}
@@ -116,7 +117,7 @@ func (ra *SubjectAccess) Print(w io.Writer, converter CodeConverter, requestedVe
 		if !verbs.HasAny(requestedVerbs...) {
 			continue
 		}
-		fmt.Fprintf(w, "%s\t%s", subject.Name, subject.Kind)
+		fmt.Fprintf(w, "%s\t%s\t%s", subject.Name, subject.Kind, subject.Namespace)
 		for _, v := range requestedVerbs {
 			var code int
 			if verbs.Has(v) {

--- a/pkg/rakkess/client/result/subject.go
+++ b/pkg/rakkess/client/result/subject.go
@@ -113,6 +113,9 @@ func (ra *SubjectAccess) Print(w io.Writer, converter CodeConverter, requestedVe
 	// table body
 	for _, subject := range subjects {
 		verbs := ra.subjectAccess[subject]
+		if !verbs.HasAny(requestedVerbs...) {
+			continue
+		}
 		fmt.Fprintf(w, "%s\t%s", subject.Name, subject.Kind)
 		for _, v := range requestedVerbs {
 			var code int

--- a/pkg/rakkess/client/result/subject_test.go
+++ b/pkg/rakkess/client/result/subject_test.go
@@ -185,6 +185,16 @@ func TestSubjectAccess_Print(t *testing.T) {
 			verbs:    []string{"list", "get"},
 			expected: "NAME\tKIND\tLIST\tGET\na-default\tSA\tyes\tno\nb-default\tSA\tyes\tyes\nc-default\tSA\tno\tyes\n",
 		},
+		{
+			name: "ignore row without matches",
+			subjectAccess: map[SubjectRef]sets.String{
+				SubjectRef{Name: "c-default", Kind: "SA"}: sets.NewString("get", "delete"),
+				SubjectRef{Name: "b-default", Kind: "SA"}: sets.NewString("delete", "update"),
+				SubjectRef{Name: "a-default", Kind: "SA"}: sets.NewString("list", "delete"),
+			},
+			verbs:    []string{"list", "get"},
+			expected: "NAME\tKIND\tLIST\tGET\na-default\tSA\tyes\tno\nc-default\tSA\tno\tyes\n",
+		},
 	}
 
 	for _, test := range tests {

--- a/pkg/rakkess/client/result/subject_test.go
+++ b/pkg/rakkess/client/result/subject_test.go
@@ -170,30 +170,30 @@ func TestSubjectAccess_Print(t *testing.T) {
 		{
 			name: "single row with multiple verbs",
 			subjectAccess: map[SubjectRef]sets.String{
-				SubjectRef{Name: "default", Kind: "service-account"}: sets.NewString("list", "delete"),
+				SubjectRef{Name: "default", Kind: "service-account", Namespace: "some-ns"}: sets.NewString("list", "delete"),
 			},
 			verbs:    []string{"list", "get"},
-			expected: "NAME\tKIND\tLIST\tGET\ndefault\tservice-account\tyes\tno\n",
+			expected: "NAME\tKIND\tSA-NAMESPACE\tLIST\tGET\ndefault\tservice-account\tsome-ns\tyes\tno\n",
 		},
 		{
 			name: "multiple rows with multiple verbs",
 			subjectAccess: map[SubjectRef]sets.String{
-				SubjectRef{Name: "c-default", Kind: "SA"}: sets.NewString("get", "delete"),
-				SubjectRef{Name: "b-default", Kind: "SA"}: sets.NewString("list", "get"),
-				SubjectRef{Name: "a-default", Kind: "SA"}: sets.NewString("list", "delete"),
+				SubjectRef{Name: "c-default", Kind: "SA-c", Namespace: "ns-c"}: sets.NewString("get", "delete"),
+				SubjectRef{Name: "b-default", Kind: "SA-b", Namespace: "ns-b"}: sets.NewString("list", "get"),
+				SubjectRef{Name: "a-default", Kind: "SA-a", Namespace: "ns-a"}: sets.NewString("list", "delete"),
 			},
 			verbs:    []string{"list", "get"},
-			expected: "NAME\tKIND\tLIST\tGET\na-default\tSA\tyes\tno\nb-default\tSA\tyes\tyes\nc-default\tSA\tno\tyes\n",
+			expected: "NAME\tKIND\tSA-NAMESPACE\tLIST\tGET\na-default\tSA-a\tns-a\tyes\tno\nb-default\tSA-b\tns-b\tyes\tyes\nc-default\tSA-c\tns-c\tno\tyes\n",
 		},
 		{
 			name: "ignore row without matches",
 			subjectAccess: map[SubjectRef]sets.String{
-				SubjectRef{Name: "c-default", Kind: "SA"}: sets.NewString("get", "delete"),
-				SubjectRef{Name: "b-default", Kind: "SA"}: sets.NewString("delete", "update"),
-				SubjectRef{Name: "a-default", Kind: "SA"}: sets.NewString("list", "delete"),
+				SubjectRef{Name: "c-default", Kind: "SA-c", Namespace: "ns-c"}: sets.NewString("get", "delete"),
+				SubjectRef{Name: "b-default", Kind: "SA-b", Namespace: "ns-b"}: sets.NewString("delete", "update"),
+				SubjectRef{Name: "a-default", Kind: "SA-a", Namespace: "ns-a"}: sets.NewString("list", "delete"),
 			},
 			verbs:    []string{"list", "get"},
-			expected: "NAME\tKIND\tLIST\tGET\na-default\tSA\tyes\tno\nc-default\tSA\tno\tyes\n",
+			expected: "NAME\tKIND\tSA-NAMESPACE\tLIST\tGET\na-default\tSA-a\tns-a\tyes\tno\nc-default\tSA-c\tns-c\tno\tyes\n",
 		},
 	}
 
@@ -243,12 +243,13 @@ func makeSubjects(in []string) []v1.Subject {
 	var subjects []v1.Subject
 	for _, s := range in {
 		subjects = append(subjects, v1.Subject{
-			Name: s,
-			Kind: "some-kind",
+			Name:      s,
+			Kind:      "some-kind",
+			Namespace: "some-ns",
 		})
 	}
 	return subjects
 }
 func toSubject(name string) SubjectRef {
-	return SubjectRef{Name: name, Kind: "some-kind"}
+	return SubjectRef{Name: name, Kind: "some-kind", Namespace: "some-ns"}
 }

--- a/pkg/rakkess/client/result/subject_test.go
+++ b/pkg/rakkess/client/result/subject_test.go
@@ -1,0 +1,168 @@
+/*
+Copyright 2019 Cornelius Weig
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package result
+
+import (
+	"testing"
+
+	"github.com/corneliusweig/rakkess/pkg/rakkess/constants"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+func TestSubjectAccess_MatchRules(t *testing.T) {
+	r := RoleRef{
+		Name: "some-role",
+		Kind: "some-kind",
+	}
+	resource := "deployments"
+	tests := []struct {
+		name          string
+		initialVerbs  []string
+		rule          v1.PolicyRule
+		expectedVerbs []string
+	}{
+		{
+			name: "simple rule",
+			rule: v1.PolicyRule{
+				Resources: []string{resource},
+				Verbs:     []string{"create", "get"},
+			},
+			expectedVerbs: []string{"create", "get"},
+		},
+		{
+			name:         "simple rule with initial verbs",
+			initialVerbs: []string{"initial", "other"},
+			rule: v1.PolicyRule{
+				Resources: []string{resource},
+				Verbs:     []string{"create", "get"},
+			},
+			expectedVerbs: []string{"create", "get", "initial", "other"},
+		},
+		{
+			name: "rule for multiple resources",
+			rule: v1.PolicyRule{
+				Resources: []string{"resource-other", resource, "resource-yet-another"},
+				Verbs:     []string{"create", "get"},
+			},
+			expectedVerbs: []string{"create", "get"},
+		},
+		{
+			name: "no matching resource",
+			rule: v1.PolicyRule{
+				Resources: []string{"resource-other", "resource-yet-another"},
+				Verbs:     []string{"create", "get"},
+			},
+		},
+		{
+			name: "VerbAll",
+			rule: v1.PolicyRule{
+				Resources: []string{resource},
+				Verbs:     []string{v1.VerbAll},
+			},
+			expectedVerbs: constants.ValidVerbs,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			sa := NewSubjectAccess(resource)
+			if test.initialVerbs != nil {
+				sa.roles[r] = sets.NewString(test.initialVerbs...)
+			}
+			sa.MatchRules(r, test.rule)
+
+			if test.expectedVerbs != nil {
+				assert.Equal(t, sets.NewString(test.expectedVerbs...), sa.roles[r])
+			} else {
+				_, ok := sa.roles[r]
+				assert.False(t, ok)
+			}
+		})
+	}
+}
+
+func TestSubjectAccess_ResolveRoleRef(t *testing.T) {
+	r := RoleRef{
+		Name: "some-role",
+		Kind: "some-kind",
+	}
+	subject := "main"
+	mainSubject := toSubject(subject)
+	tests := []struct {
+		name          string
+		verbsForRole  []string
+		subjects      []string
+		expectedVerbs []string
+	}{
+		{
+			name:          "no role",
+			subjects:      []string{subject},
+			expectedVerbs: []string{"initial-verb"},
+		},
+		{
+			name:          "match with one subject",
+			verbsForRole:  []string{"get", "list"},
+			subjects:      []string{subject},
+			expectedVerbs: []string{"initial-verb", "get", "list"},
+		},
+		{
+			name:          "match with multiple subject",
+			verbsForRole:  []string{"get", "list"},
+			subjects:      []string{"other", subject, "yet-another"},
+			expectedVerbs: []string{"initial-verb", "get", "list"},
+		},
+		{
+			name:          "no match with other subjects",
+			verbsForRole:  []string{"get", "list"},
+			subjects:      []string{"other", "yet-another"},
+			expectedVerbs: []string{"initial-verb"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			sa := SubjectAccess{
+				subjectAccess: map[SubjectRef]sets.String{mainSubject: sets.NewString("initial-verb")},
+				roles:         make(map[RoleRef]sets.String),
+			}
+			if test.verbsForRole != nil {
+				sa.roles[r] = sets.NewString(test.verbsForRole...)
+			}
+
+			sa.ResolveRoleRef(r, makeSubjects(test.subjects))
+
+			assert.Equal(t, sets.NewString(test.expectedVerbs...), sa.subjectAccess[mainSubject])
+		})
+	}
+}
+
+func makeSubjects(in []string) []v1.Subject {
+	var subjects []v1.Subject
+	for _, s := range in {
+		subjects = append(subjects, v1.Subject{
+			Name: s,
+			Kind: "some-kind",
+		})
+	}
+	return subjects
+}
+
+func toSubject(name string) SubjectRef {
+	return SubjectRef{Name: name, Kind: "some-kind"}
+}

--- a/pkg/rakkess/client/user_access.go
+++ b/pkg/rakkess/client/user_access.go
@@ -27,13 +27,6 @@ import (
 	authv1 "k8s.io/client-go/kubernetes/typed/authorization/v1"
 )
 
-const (
-	AccessAllowed = iota
-	AccessDenied
-	AccessNotApplicable
-	AccessRequestErr
-)
-
 // todo(corneliusweig) error is always nil
 func CheckResourceAccess(ctx context.Context, sar authv1.SelfSubjectAccessReviewInterface, grs []GroupResource, verbs []string, namespace *string) (result.ResourceAccess, error) {
 	var results []result.ResourceAccessItem
@@ -85,7 +78,7 @@ func CheckResourceAccess(ctx context.Context, sar authv1.SelfSubjectAccessReview
 				}
 
 				if !allowedVerbs.Has(v) {
-					access[v] = AccessNotApplicable
+					access[v] = result.AccessNotApplicable
 					continue
 				}
 
@@ -102,7 +95,7 @@ func CheckResourceAccess(ctx context.Context, sar authv1.SelfSubjectAccessReview
 				review, e := sar.Create(review)
 				if e != nil {
 					errs = append(errs, e)
-					access[v] = AccessRequestErr
+					access[v] = result.AccessRequestErr
 				} else {
 					access[v] = resultFor(&review.Status)
 				}
@@ -132,7 +125,7 @@ func CheckResourceAccess(ctx context.Context, sar authv1.SelfSubjectAccessReview
 
 func resultFor(status *v1.SubjectAccessReviewStatus) int {
 	if status.Allowed {
-		return AccessAllowed
+		return result.AccessAllowed
 	}
-	return AccessDenied
+	return result.AccessDenied
 }

--- a/pkg/rakkess/client/user_access.go
+++ b/pkg/rakkess/client/user_access.go
@@ -28,7 +28,7 @@ import (
 )
 
 // todo(corneliusweig) error is always nil
-func CheckResourceAccess(ctx context.Context, sar authv1.SelfSubjectAccessReviewInterface, grs []GroupResource, verbs []string, namespace *string) (result.ResourceAccess, error) {
+func CheckResourceAccess(ctx context.Context, sar authv1.SelfSubjectAccessReviewInterface, grs []GroupResource, verbs []string, namespace *string) (result.MatrixPrinter, error) {
 	var results []result.ResourceAccessItem
 	group := sync.WaitGroup{}
 	semaphore := make(chan struct{}, 20)

--- a/pkg/rakkess/client/user_access_test.go
+++ b/pkg/rakkess/client/user_access_test.go
@@ -77,7 +77,7 @@ func TestCheckResourceAccess(t *testing.T) {
 		verbs     []string
 		input     []GroupResource
 		decisions []*SelfSubjectAccessReviewDecision
-		expected  []Result
+		expected  []ResourceAccess
 	}{
 		{
 			name:  "single resource, single verb",
@@ -93,7 +93,7 @@ func TestCheckResourceAccess(t *testing.T) {
 					AccessAllowed,
 				},
 			},
-			expected: []Result{
+			expected: []ResourceAccess{
 				{Name: "resource1.group1", Access: buildAccess().allowed("list").get()},
 			},
 		},
@@ -101,7 +101,7 @@ func TestCheckResourceAccess(t *testing.T) {
 			name:  "single resource, invalid verb",
 			verbs: []string{"patch"},
 			input: []GroupResource{toGroupResource("group1", "resource1", "list")},
-			expected: []Result{
+			expected: []ResourceAccess{
 				{Name: "resource1.group1", Access: buildAccess().withResult(AccessNotApplicable, "patch").get()},
 			},
 		},
@@ -123,7 +123,7 @@ func TestCheckResourceAccess(t *testing.T) {
 					AccessDenied,
 				},
 			},
-			expected: []Result{
+			expected: []ResourceAccess{
 				{
 					Name:   "resource1.group1",
 					Access: buildAccess().allowed("list", "create").denied("delete").get(),
@@ -147,7 +147,7 @@ func TestCheckResourceAccess(t *testing.T) {
 					AccessDenied,
 				},
 			},
-			expected: []Result{
+			expected: []ResourceAccess{
 				{
 					Name:   "resource1.group1",
 					Access: buildAccess().allowed("list").get(),
@@ -184,7 +184,7 @@ func TestCheckResourceAccess(t *testing.T) {
 					AccessAllowed,
 				},
 			},
-			expected: []Result{
+			expected: []ResourceAccess{
 				{
 					Name:   "resource1.group1",
 					Access: buildAccess().allowed("list").denied("create").get(),
@@ -233,27 +233,27 @@ func TestSortResult(t *testing.T) {
 	}
 	tests := []struct {
 		name   string
-		input  []Result
-		sorted []Result
+		input  []ResourceAccess
+		sorted []ResourceAccess
 	}{
 		{
 			name:   "two inputs",
-			input:  []Result{{Name: "b second"}, {Name: "a first"}},
-			sorted: []Result{{Name: "a first"}, {Name: "b second"}},
+			input:  []ResourceAccess{{Name: "b second"}, {Name: "a first"}},
+			sorted: []ResourceAccess{{Name: "a first"}, {Name: "b second"}},
 		},
 		{
 			name:   "three inputs",
-			input:  []Result{{Name: "b second"}, {Name: "c third"}, {Name: "a first"}},
-			sorted: []Result{{Name: "a first"}, {Name: "b second"}, {Name: "c third"}},
+			input:  []ResourceAccess{{Name: "b second"}, {Name: "c third"}, {Name: "a first"}},
+			sorted: []ResourceAccess{{Name: "a first"}, {Name: "b second"}, {Name: "c third"}},
 		},
 		{
 			name: "three inputs, stable",
-			input: []Result{
+			input: []ResourceAccess{
 				{Name: "same", Access: makeResult("b", 1)},
 				{Name: "same", Access: makeResult("a", 2)},
 				{Name: "same", Access: makeResult("c", 3)},
 			},
-			sorted: []Result{
+			sorted: []ResourceAccess{
 				{Name: "same", Access: makeResult("b", 1)},
 				{Name: "same", Access: makeResult("a", 2)},
 				{Name: "same", Access: makeResult("c", 3)},
@@ -263,7 +263,7 @@ func TestSortResult(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			sort.Stable(sortableResult(test.input))
+			sort.Stable(sortableResourceAccess(test.input))
 			assert.Equal(t, test.sorted, test.input)
 		})
 	}

--- a/pkg/rakkess/client/user_access_test.go
+++ b/pkg/rakkess/client/user_access_test.go
@@ -50,10 +50,10 @@ func (a accessResult) withResult(result int, verbs ...string) accessResult {
 	return a
 }
 func (a accessResult) allowed(verbs ...string) accessResult {
-	return a.withResult(AccessAllowed, verbs...)
+	return a.withResult(result.AccessAllowed, verbs...)
 }
 func (a accessResult) denied(verbs ...string) accessResult {
-	return a.withResult(AccessDenied, verbs...)
+	return a.withResult(result.AccessDenied, verbs...)
 }
 func (a accessResult) get() map[string]int {
 	return a
@@ -90,7 +90,7 @@ func TestCheckResourceAccess(t *testing.T) {
 						Group:    "group1",
 						Verb:     "list",
 					},
-					AccessAllowed,
+					result.AccessAllowed,
 				},
 			},
 			expected: []result.ResourceAccessItem{
@@ -102,7 +102,7 @@ func TestCheckResourceAccess(t *testing.T) {
 			verbs: []string{"patch"},
 			input: []GroupResource{toGroupResource("group1", "resource1", "list")},
 			expected: []result.ResourceAccessItem{
-				{Name: "resource1.group1", Access: buildAccess().withResult(AccessNotApplicable, "patch").get()},
+				{Name: "resource1.group1", Access: buildAccess().withResult(result.AccessNotApplicable, "patch").get()},
 			},
 		},
 		{
@@ -112,15 +112,15 @@ func TestCheckResourceAccess(t *testing.T) {
 			decisions: []*SelfSubjectAccessReviewDecision{
 				{
 					v1.ResourceAttributes{Resource: "resource1", Group: "group1", Verb: "list"},
-					AccessAllowed,
+					result.AccessAllowed,
 				},
 				{
 					v1.ResourceAttributes{Resource: "resource1", Group: "group1", Verb: "create"},
-					AccessAllowed,
+					result.AccessAllowed,
 				},
 				{
 					v1.ResourceAttributes{Resource: "resource1", Group: "group1", Verb: "delete"},
-					AccessDenied,
+					result.AccessDenied,
 				},
 			},
 			expected: []result.ResourceAccessItem{
@@ -140,11 +140,11 @@ func TestCheckResourceAccess(t *testing.T) {
 			decisions: []*SelfSubjectAccessReviewDecision{
 				{
 					v1.ResourceAttributes{Resource: "resource1", Group: "group1", Verb: "list"},
-					AccessAllowed,
+					result.AccessAllowed,
 				},
 				{
 					v1.ResourceAttributes{Resource: "resource2", Group: "group1", Verb: "list"},
-					AccessDenied,
+					result.AccessDenied,
 				},
 			},
 			expected: []result.ResourceAccessItem{
@@ -169,19 +169,19 @@ func TestCheckResourceAccess(t *testing.T) {
 			decisions: []*SelfSubjectAccessReviewDecision{
 				{
 					v1.ResourceAttributes{Resource: "resource1", Group: "group1", Verb: "list"},
-					AccessAllowed,
+					result.AccessAllowed,
 				},
 				{
 					v1.ResourceAttributes{Resource: "resource1", Group: "group1", Verb: "create"},
-					AccessDenied,
+					result.AccessDenied,
 				},
 				{
 					v1.ResourceAttributes{Resource: "resource2", Group: "group1", Verb: "create"},
-					AccessDenied,
+					result.AccessDenied,
 				},
 				{
 					v1.ResourceAttributes{Resource: "resource1", Group: "group2", Verb: "list"},
-					AccessAllowed,
+					result.AccessAllowed,
 				},
 			},
 			expected: []result.ResourceAccessItem{
@@ -191,11 +191,11 @@ func TestCheckResourceAccess(t *testing.T) {
 				},
 				{
 					Name:   "resource1.group2",
-					Access: buildAccess().withResult(AccessNotApplicable, "create").allowed("list").get(),
+					Access: buildAccess().withResult(result.AccessNotApplicable, "create").allowed("list").get(),
 				},
 				{
 					Name:   "resource2.group1",
-					Access: buildAccess().denied("create").withResult(AccessNotApplicable, "list").get(),
+					Access: buildAccess().denied("create").withResult(result.AccessNotApplicable, "list").get(),
 				},
 			},
 		},
@@ -210,7 +210,7 @@ func TestCheckResourceAccess(t *testing.T) {
 
 					for _, d := range test.decisions {
 						if d.matches(sar) {
-							sar.Status.Allowed = d.decision == AccessAllowed
+							sar.Status.Allowed = d.decision == result.AccessAllowed
 							return true, sar, nil
 						}
 					}

--- a/pkg/rakkess/constants/constants.go
+++ b/pkg/rakkess/constants/constants.go
@@ -24,13 +24,14 @@ const (
 
 var (
 	ValidVerbs = []string{
+		"create",
+		"delete",
+		"deletecollection",
 		"get",
 		"list",
-		"watch",
-		"create",
+		"patch",
 		"update",
-		"delete",
-		"proxy",
+		"watch",
 	}
 	ValidOutputFormats = []string{
 		"icon-table",

--- a/pkg/rakkess/options/options.go
+++ b/pkg/rakkess/options/options.go
@@ -25,10 +25,10 @@ import (
 )
 
 type RakkessOptions struct {
-	ConfigFlags *genericclioptions.ConfigFlags
-	Verbs       []string
-	Output      string
-	Streams     *genericclioptions.IOStreams
+	ConfigFlags  *genericclioptions.ConfigFlags
+	Verbs        []string
+	OutputFormat string
+	Streams      *genericclioptions.IOStreams
 }
 
 func NewRakkessOptions() *RakkessOptions {

--- a/pkg/rakkess/printer/printer.go
+++ b/pkg/rakkess/printer/printer.go
@@ -19,10 +19,10 @@ package printer
 import (
 	"fmt"
 	"io"
-	"strings"
 	"sync"
 
 	"github.com/corneliusweig/rakkess/pkg/rakkess/client"
+	"github.com/corneliusweig/rakkess/pkg/rakkess/client/result"
 )
 
 type color int
@@ -39,17 +39,11 @@ var (
 	terminit   sync.Once
 )
 
-func PrintResults(out io.Writer, requestedVerbs []string, outputFormat string, results []client.ResourceAccess) {
+func PrintResults(out io.Writer, requestedVerbs []string, outputFormat string, results result.ResourceAccess) {
 	w := NewWriter(out, 4, 8, 2, ' ', CollapseEscape|StripEscape)
 	defer w.Flush()
 
 	terminit.Do(func() { initTerminal(out) })
-
-	fmt.Fprint(w, "NAME")
-	for _, v := range requestedVerbs {
-		fmt.Fprintf(w, "\t%s", strings.ToUpper(v))
-	}
-	fmt.Fprint(w, "\n")
 
 	codeConverter := humanreadableAccessCode
 	if IsTerminal(out) {
@@ -59,13 +53,7 @@ func PrintResults(out io.Writer, requestedVerbs []string, outputFormat string, r
 		codeConverter = asciiAccessCode
 	}
 
-	for _, r := range results {
-		fmt.Fprintf(w, "%s", r.Name)
-		for _, v := range requestedVerbs {
-			fmt.Fprintf(w, "\t%s", codeConverter(r.Access[v]))
-		}
-		fmt.Fprint(w, "\n")
-	}
+	results.Print(w, codeConverter, requestedVerbs)
 }
 
 func humanreadableAccessCode(code int) string {

--- a/pkg/rakkess/printer/printer.go
+++ b/pkg/rakkess/printer/printer.go
@@ -46,7 +46,7 @@ const (
 	ASCIITable OutputFormat = iota
 )
 
-func PrintResults(out io.Writer, requestedVerbs []string, outputFormat OutputFormat, results []client.Result) {
+func PrintResults(out io.Writer, requestedVerbs []string, outputFormat OutputFormat, results []client.ResourceAccess) {
 	w := NewWriter(out, 4, 8, 2, ' ', CollapseEscape|StripEscape)
 	defer w.Flush()
 

--- a/pkg/rakkess/printer/printer.go
+++ b/pkg/rakkess/printer/printer.go
@@ -38,7 +38,7 @@ var (
 	terminit   sync.Once
 )
 
-func PrintResults(out io.Writer, requestedVerbs []string, outputFormat string, results result.ResourceAccess) {
+func PrintResults(out io.Writer, requestedVerbs []string, outputFormat string, results result.MatrixPrinter) {
 	w := NewWriter(out, 4, 8, 2, ' ', CollapseEscape|StripEscape)
 	defer w.Flush()
 

--- a/pkg/rakkess/printer/printer.go
+++ b/pkg/rakkess/printer/printer.go
@@ -39,14 +39,7 @@ var (
 	terminit   sync.Once
 )
 
-type OutputFormat int
-
-const (
-	IconTable  OutputFormat = iota
-	ASCIITable OutputFormat = iota
-)
-
-func PrintResults(out io.Writer, requestedVerbs []string, outputFormat OutputFormat, results []client.ResourceAccess) {
+func PrintResults(out io.Writer, requestedVerbs []string, outputFormat string, results []client.ResourceAccess) {
 	w := NewWriter(out, 4, 8, 2, ' ', CollapseEscape|StripEscape)
 	defer w.Flush()
 
@@ -62,7 +55,7 @@ func PrintResults(out io.Writer, requestedVerbs []string, outputFormat OutputFor
 	if IsTerminal(out) {
 		codeConverter = colorHumanreadableAccessCode
 	}
-	if outputFormat == ASCIITable {
+	if outputFormat == "ascii-table" {
 		codeConverter = asciiAccessCode
 	}
 

--- a/pkg/rakkess/printer/printer.go
+++ b/pkg/rakkess/printer/printer.go
@@ -21,7 +21,6 @@ import (
 	"io"
 	"sync"
 
-	"github.com/corneliusweig/rakkess/pkg/rakkess/client"
 	"github.com/corneliusweig/rakkess/pkg/rakkess/client/result"
 )
 
@@ -58,13 +57,13 @@ func PrintResults(out io.Writer, requestedVerbs []string, outputFormat string, r
 
 func humanreadableAccessCode(code int) string {
 	switch code {
-	case client.AccessAllowed:
+	case result.AccessAllowed:
 		return "✔" // ✓
-	case client.AccessDenied:
+	case result.AccessDenied:
 		return "✖" // ✕
-	case client.AccessNotApplicable:
+	case result.AccessNotApplicable:
 		return ""
-	case client.AccessRequestErr:
+	case result.AccessRequestErr:
 		return "ERR"
 	default:
 		panic("unknown access code")
@@ -77,13 +76,13 @@ func colorHumanreadableAccessCode(code int) string {
 
 func codeToColor(code int) color {
 	switch code {
-	case client.AccessAllowed:
+	case result.AccessAllowed:
 		return green
-	case client.AccessDenied:
+	case result.AccessDenied:
 		return red
-	case client.AccessNotApplicable:
+	case result.AccessNotApplicable:
 		return none
-	case client.AccessRequestErr:
+	case result.AccessRequestErr:
 		return purple
 	}
 	return none
@@ -91,13 +90,13 @@ func codeToColor(code int) color {
 
 func asciiAccessCode(code int) string {
 	switch code {
-	case client.AccessAllowed:
+	case result.AccessAllowed:
 		return "yes"
-	case client.AccessDenied:
+	case result.AccessDenied:
 		return "no"
-	case client.AccessNotApplicable:
+	case result.AccessNotApplicable:
 		return "n/a"
-	case client.AccessRequestErr:
+	case result.AccessRequestErr:
 		return "ERR"
 	default:
 		panic("unknown access code")

--- a/pkg/rakkess/printer/printer_test.go
+++ b/pkg/rakkess/printer/printer_test.go
@@ -21,7 +21,6 @@ import (
 	"io"
 	"testing"
 
-	"github.com/corneliusweig/rakkess/pkg/rakkess/client"
 	"github.com/corneliusweig/rakkess/pkg/rakkess/client/result"
 	"github.com/stretchr/testify/assert"
 )
@@ -38,10 +37,10 @@ func (a accessResult) withResult(result int, verbs ...string) accessResult {
 	return a
 }
 func (a accessResult) allowed(verbs ...string) accessResult {
-	return a.withResult(client.AccessAllowed, verbs...)
+	return a.withResult(result.AccessAllowed, verbs...)
 }
 func (a accessResult) denied(verbs ...string) accessResult {
-	return a.withResult(client.AccessDenied, verbs...)
+	return a.withResult(result.AccessDenied, verbs...)
 }
 func (a accessResult) get() map[string]int {
 	return a
@@ -80,7 +79,7 @@ func TestPrintResults(t *testing.T) {
 			"single result, all not applicable",
 			[]string{"get", "list"},
 			[]result.ResourceAccessItem{
-				{Name: "resource1", Access: buildAccess().withResult(client.AccessNotApplicable, "get", "list").get()},
+				{Name: "resource1", Access: buildAccess().withResult(result.AccessNotApplicable, "get", "list").get()},
 			},
 			HEADER + "resource1       \n",
 			HEADER + "resource1  \033[0m\033[0m     \033[0m\033[0m\n",
@@ -90,7 +89,7 @@ func TestPrintResults(t *testing.T) {
 			"single result, all ERR",
 			[]string{"get", "list"},
 			[]result.ResourceAccessItem{
-				{Name: "resource1", Access: buildAccess().withResult(client.AccessRequestErr, "get", "list").get()},
+				{Name: "resource1", Access: buildAccess().withResult(result.AccessRequestErr, "get", "list").get()},
 			},
 			HEADER + "resource1  ERR  ERR\n",
 			HEADER + "resource1  \033[35mERR\033[0m  \033[35mERR\033[0m\n",

--- a/pkg/rakkess/printer/printer_test.go
+++ b/pkg/rakkess/printer/printer_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/corneliusweig/rakkess/pkg/rakkess/client"
+	"github.com/corneliusweig/rakkess/pkg/rakkess/client/result"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -52,7 +53,7 @@ func TestPrintResults(t *testing.T) {
 	tests := []struct {
 		name          string
 		verbs         []string
-		given         []client.ResourceAccess
+		given         result.ResourceAccess
 		expected      string
 		expectedColor string
 		expectedASCII string
@@ -60,9 +61,7 @@ func TestPrintResults(t *testing.T) {
 		{
 			"single result, all allowed",
 			[]string{"get", "list"},
-			[]client.ResourceAccess{
-				{Name: "resource1", Access: buildAccess().allowed("get", "list").get()},
-			},
+			[]result.ResourceAccessItem{{Name: "resource1", Access: buildAccess().allowed("get", "list").get()}},
 			HEADER + "resource1  ✔    ✔\n",
 			HEADER + "resource1  \033[32m✔\033[0m    \033[32m✔\033[0m\n",
 			HEADER + "resource1  yes  yes\n",
@@ -70,7 +69,7 @@ func TestPrintResults(t *testing.T) {
 		{
 			"single result, all forbidden",
 			[]string{"get", "list"},
-			[]client.ResourceAccess{
+			[]result.ResourceAccessItem{
 				{Name: "resource1", Access: buildAccess().denied("get", "list").get()},
 			},
 			HEADER + "resource1  ✖    ✖\n",
@@ -80,7 +79,7 @@ func TestPrintResults(t *testing.T) {
 		{
 			"single result, all not applicable",
 			[]string{"get", "list"},
-			[]client.ResourceAccess{
+			[]result.ResourceAccessItem{
 				{Name: "resource1", Access: buildAccess().withResult(client.AccessNotApplicable, "get", "list").get()},
 			},
 			HEADER + "resource1       \n",
@@ -90,7 +89,7 @@ func TestPrintResults(t *testing.T) {
 		{
 			"single result, all ERR",
 			[]string{"get", "list"},
-			[]client.ResourceAccess{
+			[]result.ResourceAccessItem{
 				{Name: "resource1", Access: buildAccess().withResult(client.AccessRequestErr, "get", "list").get()},
 			},
 			HEADER + "resource1  ERR  ERR\n",
@@ -100,7 +99,7 @@ func TestPrintResults(t *testing.T) {
 		{
 			"single result, mixed",
 			[]string{"get", "list"},
-			[]client.ResourceAccess{
+			[]result.ResourceAccessItem{
 				{Name: "resource1", Access: buildAccess().allowed("list").denied("get").get()},
 			},
 			HEADER + "resource1  ✖    ✔\n",
@@ -110,7 +109,7 @@ func TestPrintResults(t *testing.T) {
 		{
 			"many results",
 			[]string{"get"},
-			[]client.ResourceAccess{
+			[]result.ResourceAccessItem{
 				{Name: "resource1", Access: buildAccess().denied("get").get()},
 				{Name: "resource2", Access: buildAccess().allowed("get").get()},
 				{Name: "resource3", Access: buildAccess().denied("get").get()},

--- a/pkg/rakkess/printer/printer_test.go
+++ b/pkg/rakkess/printer/printer_test.go
@@ -52,7 +52,7 @@ func TestPrintResults(t *testing.T) {
 	tests := []struct {
 		name          string
 		verbs         []string
-		given         []client.Result
+		given         []client.ResourceAccess
 		expected      string
 		expectedColor string
 		expectedASCII string
@@ -60,7 +60,7 @@ func TestPrintResults(t *testing.T) {
 		{
 			"single result, all allowed",
 			[]string{"get", "list"},
-			[]client.Result{
+			[]client.ResourceAccess{
 				{Name: "resource1", Access: buildAccess().allowed("get", "list").get()},
 			},
 			HEADER + "resource1  ✔    ✔\n",
@@ -70,7 +70,7 @@ func TestPrintResults(t *testing.T) {
 		{
 			"single result, all forbidden",
 			[]string{"get", "list"},
-			[]client.Result{
+			[]client.ResourceAccess{
 				{Name: "resource1", Access: buildAccess().denied("get", "list").get()},
 			},
 			HEADER + "resource1  ✖    ✖\n",
@@ -80,7 +80,7 @@ func TestPrintResults(t *testing.T) {
 		{
 			"single result, all not applicable",
 			[]string{"get", "list"},
-			[]client.Result{
+			[]client.ResourceAccess{
 				{Name: "resource1", Access: buildAccess().withResult(client.AccessNotApplicable, "get", "list").get()},
 			},
 			HEADER + "resource1       \n",
@@ -90,7 +90,7 @@ func TestPrintResults(t *testing.T) {
 		{
 			"single result, all ERR",
 			[]string{"get", "list"},
-			[]client.Result{
+			[]client.ResourceAccess{
 				{Name: "resource1", Access: buildAccess().withResult(client.AccessRequestErr, "get", "list").get()},
 			},
 			HEADER + "resource1  ERR  ERR\n",
@@ -100,7 +100,7 @@ func TestPrintResults(t *testing.T) {
 		{
 			"single result, mixed",
 			[]string{"get", "list"},
-			[]client.Result{
+			[]client.ResourceAccess{
 				{Name: "resource1", Access: buildAccess().allowed("list").denied("get").get()},
 			},
 			HEADER + "resource1  ✖    ✔\n",
@@ -110,7 +110,7 @@ func TestPrintResults(t *testing.T) {
 		{
 			"many results",
 			[]string{"get"},
-			[]client.Result{
+			[]client.ResourceAccess{
 				{Name: "resource1", Access: buildAccess().denied("get").get()},
 				{Name: "resource2", Access: buildAccess().allowed("get").get()},
 				{Name: "resource3", Access: buildAccess().denied("get").get()},

--- a/pkg/rakkess/printer/printer_test.go
+++ b/pkg/rakkess/printer/printer_test.go
@@ -125,13 +125,13 @@ func TestPrintResults(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			buf := &bytes.Buffer{}
 
-			PrintResults(buf, test.verbs, IconTable, test.given)
+			PrintResults(buf, test.verbs, "icon-table", test.given)
 
 			assert.Equal(t, test.expected, buf.String())
 
 			buf = &bytes.Buffer{}
 
-			PrintResults(buf, test.verbs, ASCIITable, test.given)
+			PrintResults(buf, test.verbs, "ascii-table", test.given)
 
 			assert.Equal(t, test.expectedASCII, buf.String())
 		})
@@ -149,13 +149,13 @@ func TestPrintResults(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			buf := &bytes.Buffer{}
 
-			PrintResults(buf, test.verbs, IconTable, test.given)
+			PrintResults(buf, test.verbs, "icon-table", test.given)
 
 			assert.Equal(t, test.expectedColor, buf.String())
 
 			buf = &bytes.Buffer{}
 
-			PrintResults(buf, test.verbs, ASCIITable, test.given)
+			PrintResults(buf, test.verbs, "ascii-table", test.given)
 
 			assert.Equal(t, test.expectedASCII, buf.String())
 		})

--- a/pkg/rakkess/rakkess.go
+++ b/pkg/rakkess/rakkess.go
@@ -37,7 +37,7 @@ func Rakkess(ctx context.Context, opts *options.RakkessOptions) error {
 	if err != nil {
 		return errors.Wrap(err, "fetch available group resources")
 	}
-	logrus.Info(grs)
+	logrus.Debug(grs)
 
 	authClient, err := opts.GetAuthClient()
 	if err != nil {
@@ -50,18 +50,11 @@ func Rakkess(ctx context.Context, opts *options.RakkessOptions) error {
 		return errors.Wrap(err, "check resource access")
 	}
 
-	printer.PrintResults(opts.Streams.Out, opts.Verbs, outputFormat(opts), results)
+	printer.PrintResults(opts.Streams.Out, opts.Verbs, opts.OutputFormat, results)
 
 	if namespace == nil || *namespace == "" {
 		fmt.Fprintf(opts.Streams.Out, "No namespace given, this implies cluster scope (try -n if this is not intended)\n")
 	}
 
 	return nil
-}
-
-func outputFormat(o *options.RakkessOptions) printer.OutputFormat {
-	if o.Output == "ascii-table" {
-		return printer.ASCIITable
-	}
-	return printer.IconTable
 }

--- a/pkg/rakkess/rakkess.go
+++ b/pkg/rakkess/rakkess.go
@@ -29,7 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-func RakkessResource(ctx context.Context, opts *options.RakkessOptions) error {
+func Resource(ctx context.Context, opts *options.RakkessOptions) error {
 	if err := validation.Options(opts); err != nil {
 		return err
 	}
@@ -60,7 +60,7 @@ func RakkessResource(ctx context.Context, opts *options.RakkessOptions) error {
 	return nil
 }
 
-func RakkessSubject(opts *options.RakkessOptions, resource string) error {
+func Subject(opts *options.RakkessOptions, resource string) error {
 	if err := validation.Options(opts); err != nil {
 		return err
 	}

--- a/pkg/rakkess/validation/validation.go
+++ b/pkg/rakkess/validation/validation.go
@@ -12,7 +12,7 @@ func Options(opts *options.RakkessOptions) error {
 	if err := verbs(opts.Verbs); err != nil {
 		return err
 	}
-	if err := outputFormat(opts.Output); err != nil {
+	if err := outputFormat(opts.OutputFormat); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/rakkess/validation/validation_test.go
+++ b/pkg/rakkess/validation/validation_test.go
@@ -43,7 +43,7 @@ func TestVerbs(t *testing.T) {
 	}{
 		{
 			name:  "only valid verbs",
-			verbs: []string{"list", "get", "proxy"},
+			verbs: []string{"list", "get", "deletecollection"},
 		},
 		{
 			name:     "only invalid verbs",
@@ -52,7 +52,7 @@ func TestVerbs(t *testing.T) {
 		},
 		{
 			name:     "valid and invalid verbs",
-			verbs:    []string{"list", "git", "proxy"},
+			verbs:    []string{"list", "git", "deletecollection"},
 			expected: "unexpected verbs: [git]",
 		},
 	}


### PR DESCRIPTION
This PR adds a new subcommand `resource`. It  retrieves all (Cluster)Roles plus their bindings and evaluates the authorization for the given resource and verbs. The result is shown as a matrix with verbs in the horizontal and subjects in the vertical direction. For example:
```bash
rakkess resource deployments
```
show what subjects may globally hamper with deployments. It therefore only considers `ClusterRoles`. On the other hand,
```bash
rakkess r deploy -n default
```
shows who may deal with deployments in a particular namespace. It considers both `ClusterRoles` and `Roles`.

While the usual `rakkess` behavior slices the authorization space (subject, resource, verb) along a plane of constant subject (usually self), this new variant does a similar thing along a plane of fixed resource.

