### PR TITLE
Support wildcard for all verbs `--verbs=all` and `--verbs=*`

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -97,6 +97,7 @@ func init() {
 	AddRakkessFlags(rootCmd)
 
 	rootCmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
+		rakkessOptions.ExpandVerbs()
 		return SetUpLogs(rakkessOptions.Streams.ErrOut, v)
 	}
 }

--- a/pkg/rakkess/constants/constants.go
+++ b/pkg/rakkess/constants/constants.go
@@ -25,15 +25,16 @@ const (
 
 var (
 	// ValidVerbs is the list of allowed actions on kubernetes resources.
+	// Sort order aligned along CRUD.
 	ValidVerbs = []string{
 		"create",
-		"delete",
-		"deletecollection",
 		"get",
 		"list",
-		"patch",
-		"update",
 		"watch",
+		"update",
+		"patch",
+		"delete",
+		"deletecollection",
 	}
 
 	// ValidOutputFormats is the list of valid formats for the result table.

--- a/pkg/rakkess/options/options.go
+++ b/pkg/rakkess/options/options.go
@@ -19,6 +19,7 @@ package options
 import (
 	"os"
 
+	"github.com/corneliusweig/rakkess/pkg/rakkess/constants"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/discovery"
 	v1 "k8s.io/client-go/kubernetes/typed/authorization/v1"
@@ -61,4 +62,13 @@ func (o *RakkessOptions) GetAuthClient() (v1.SelfSubjectAccessReviewInterface, e
 // DiscoveryClient creates a kubernetes discovery client.
 func (o *RakkessOptions) DiscoveryClient() (discovery.CachedDiscoveryInterface, error) {
 	return o.ConfigFlags.ToDiscoveryClient()
+}
+
+// ExpandVerbs expands wildcard verbs `*` and `all`.
+func (o *RakkessOptions) ExpandVerbs() {
+	for _, verb := range o.Verbs {
+		if verb == "*" || verb == "all" {
+			o.Verbs = constants.ValidVerbs
+		}
+	}
 }

--- a/pkg/rakkess/options/options_test.go
+++ b/pkg/rakkess/options/options_test.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2019 Cornelius Weig
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package options
+
+import (
+	"testing"
+
+	"github.com/corneliusweig/rakkess/pkg/rakkess/constants"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRakkessOptions_ExpandVerbs(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []string
+		expected []string
+	}{
+		{
+			name:     "* wildcard",
+			input:    []string{"*"},
+			expected: constants.ValidVerbs,
+		},
+		{
+			name:     "all wildcard",
+			input:    []string{"*"},
+			expected: constants.ValidVerbs,
+		},
+		{
+			name:     "wildcard mixed with other verbs",
+			input:    []string{"list", "*", "get"},
+			expected: constants.ValidVerbs,
+		},
+		{
+			name:     "no wildcard",
+			input:    []string{"list", "get"},
+			expected: []string{"list", "get"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			opts := &RakkessOptions{Verbs: test.input}
+			opts.ExpandVerbs()
+
+			assert.Equal(t, test.expected, opts.Verbs)
+		})
+	}
+}


### PR DESCRIPTION
Close #20 