### PR TITLE
Extend the `resource` to select a particular object

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,15 @@ It lists access rights for the current user for all server resources.
   rakkess r cm --verbs get,delete,watch,patch
   ```
   
+##### Name-restricted roles
+Some roles only apply to resources with a specific name.
+To review such configurations, provide the resource name as additional argument.
+For example, consider `ConfigMaps` with name `ingress-controller-leader-nginx` in namespace `ingress-nginx`:
+
+```bash
+rakkess r cm ingress-controller-leader-nginx -n ingress-nginx --verbs=all
+```
+  
 As `rakkess resource` needs to query `Roles`, `ClusterRoles`, and their bindings, it usually requires administrative cluster access.
 
 Also see [Usage](doc/USAGE.md).

--- a/cmd/resource.go
+++ b/cmd/resource.go
@@ -54,13 +54,18 @@ More on https://github.com/corneliusweig/rakkess/blob/v0.3.0/doc/USAGE.md#usage
 // resourceCmd represents the resource command
 var resourceCmd = &cobra.Command{
 	Use:     "resource",
-	Aliases: []string{"r"},
+	Aliases: []string{"r", "for"},
 	Short:   "Show all subjects with access to a given resource",
-	Args:    cobra.ExactArgs(1),
+	Args:    cobra.RangeArgs(1, 2),
 	Long:    rakkessSubjectLong,
 	Example: rakkessSubjectExamples,
 	Run: func(cmd *cobra.Command, args []string) {
-		if err := rakkess.Subject(rakkessOptions, args[0]); err != nil {
+		resource := args[0]
+		var resourceName string
+		if len(args) == 2 {
+			resourceName = args[1]
+		}
+		if err := rakkess.Subject(rakkessOptions, resource, resourceName); err != nil {
 			logrus.Error(err)
 		}
 	},

--- a/cmd/resource.go
+++ b/cmd/resource.go
@@ -43,11 +43,14 @@ More on https://github.com/corneliusweig/rakkess/blob/v0.3.0/doc/USAGE.md#usage
   Review access to deployments in any namespace
   $ rakkess resource deployments
 
-  Review access deployments in the default namespace (with shorthands)
+  Review access to deployments in the default namespace (with shorthands)
   $ rakkess r deploy --namespace default
 
-  Review access for deployments with custom verbs
+  Review access to deployments with custom verbs
   $ rakkess r deploy --verbs get,watch,deletecollection
+
+  Review access to a config-map with a specific name
+  $ rakkess r cm config-map-name --verbs=all
 `
 )
 

--- a/doc/USAGE.md
+++ b/doc/USAGE.md
@@ -80,6 +80,15 @@ kubectl access-matrix
   kubectl access-matrix r cm --verbs get,delete,watch,patch
   ```
   
+##### Name-restricted roles
+Some roles only apply to resources with a specific name.
+To review such configurations, provide the resource name as additional argument.
+For example, consider `ConfigMaps` with name `ingress-controller-leader-nginx` in namespace `ingress-nginx`:
+
+```bash
+kubectl access-matrix r cm ingress-controller-leader-nginx -n ingress-nginx --verbs=all
+```
+  
 As `kubectl access-matrix resource` needs to query `Roles`, `ClusterRoles`, and their bindings, it usually requires administrative cluster access.
 
 ## Getting help

--- a/pkg/rakkess/client/resource_access.go
+++ b/pkg/rakkess/client/resource_access.go
@@ -35,7 +35,7 @@ const (
 )
 
 // GetSubjectAccess determines subjects with access to the given resource.
-func GetSubjectAccess(opts *options.RakkessOptions, resource string) (*result.SubjectAccess, error) {
+func GetSubjectAccess(opts *options.RakkessOptions, resource, resourceName string) (*result.SubjectAccess, error) {
 	rbacClient, err := getRbacClient(opts)
 	if err != nil {
 		return nil, err
@@ -44,7 +44,7 @@ func GetSubjectAccess(opts *options.RakkessOptions, resource string) (*result.Su
 	namespace := opts.ConfigFlags.Namespace
 	isNamespace := namespace != nil && *namespace != ""
 
-	sa := result.NewSubjectAccess(resource)
+	sa := result.NewSubjectAccess(resource, resourceName)
 
 	if err := fetchMatchingClusterRoles(rbacClient, sa); err != nil {
 		if !isNamespace {

--- a/pkg/rakkess/client/resource_access_test.go
+++ b/pkg/rakkess/client/resource_access_test.go
@@ -164,7 +164,7 @@ func TestGetSubjectAccess(t *testing.T) {
 					Namespace: &test.namespace,
 				},
 			}
-			sa, err := GetSubjectAccess(opts, test.resource)
+			sa, err := GetSubjectAccess(opts, test.resource, "")
 			assert.NoError(t, err)
 			assert.Equal(t, test.resource, sa.Resource)
 			assert.Equal(t, test.expected, sa.Get())

--- a/pkg/rakkess/client/result/subject_test.go
+++ b/pkg/rakkess/client/result/subject_test.go
@@ -35,6 +35,7 @@ func TestSubjectAccess_MatchRules(t *testing.T) {
 	resource := "deployments"
 	tests := []struct {
 		name          string
+		resourceName  string
 		initialVerbs  []string
 		rule          v1.PolicyRule
 		expectedVerbs []string
@@ -79,11 +80,38 @@ func TestSubjectAccess_MatchRules(t *testing.T) {
 			},
 			expectedVerbs: constants.ValidVerbs,
 		},
+		{
+			name: "simple rule with resourceNames does not match",
+			rule: v1.PolicyRule{
+				Resources:     []string{resource},
+				ResourceNames: []string{"no-match"},
+				Verbs:         []string{"create", "get"},
+			},
+		},
+		{
+			name:         "simple rule with matching resourceName",
+			resourceName: "my-resource-name",
+			rule: v1.PolicyRule{
+				Resources:     []string{resource},
+				ResourceNames: []string{"my-resource-name"},
+				Verbs:         []string{"create", "get"},
+			},
+			expectedVerbs: []string{"create", "get"},
+		},
+		{
+			name:         "simple rule with wrong resourceName",
+			resourceName: "my-resource-name",
+			rule: v1.PolicyRule{
+				Resources:     []string{resource},
+				ResourceNames: []string{"wrong-resource-name"},
+				Verbs:         []string{"create", "get"},
+			},
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			sa := NewSubjectAccess(resource)
+			sa := NewSubjectAccess(resource, test.resourceName)
 			if test.initialVerbs != nil {
 				sa.roles[r] = sets.NewString(test.initialVerbs...)
 			}

--- a/pkg/rakkess/rakkess.go
+++ b/pkg/rakkess/rakkess.go
@@ -66,7 +66,7 @@ func Resource(ctx context.Context, opts *options.RakkessOptions) error {
 // Subject determines the subjects with access right to the given resource and
 // prints the result as a matrix with verbs in the horizontal and subject names
 // in the vertical direction.
-func Subject(opts *options.RakkessOptions, resource string) error {
+func Subject(opts *options.RakkessOptions, resource, resourceName string) error {
 	if err := validation.Options(opts); err != nil {
 		return err
 	}
@@ -80,7 +80,7 @@ func Subject(opts *options.RakkessOptions, resource string) error {
 		return errors.Wrap(err, "determine requested resource")
 	}
 
-	subjectAccess, err := client.GetSubjectAccess(opts, versionedResource.Resource)
+	subjectAccess, err := client.GetSubjectAccess(opts, versionedResource.Resource, resourceName)
 	if err != nil {
 		return errors.Wrap(err, "get subject access")
 	}


### PR DESCRIPTION
Some `role.rules` are restricted to resources with a specific name. This PR extends the `resource` sub-command to accept an optional resourceName argument.

This also fixes a bug where rules with non-empty `resourceNames` were erroneously treated as wildcard matches.

Close #27