### PR TITLE
Allow arbitrary verbs in the resource subcommand

### DIFF
--- a/pkg/rakkess/client/result/subject.go
+++ b/pkg/rakkess/client/result/subject.go
@@ -46,7 +46,7 @@ type SubjectAccess struct {
 	ResourceName string
 	// roles holds all rule data concerning this resource and is extracted from Roles and ClusterRoles.
 	roles map[RoleRef]sets.String
-	// roles holds all subject access data for this resource and is extracted from RoleBindings and ClusterRoleBindings.
+	// subjectAccess holds all subject access data for this resource and is extracted from RoleBindings and ClusterRoleBindings.
 	subjectAccess map[SubjectRef]sets.String
 }
 

--- a/pkg/rakkess/rakkess.go
+++ b/pkg/rakkess/rakkess.go
@@ -63,7 +63,7 @@ func Resource(ctx context.Context, opts *options.RakkessOptions) error {
 // prints the result as a matrix with verbs in the horizontal and subject names
 // in the vertical direction.
 func Subject(opts *options.RakkessOptions, resource, resourceName string) error {
-	if err := validation.Options(opts); err != nil {
+	if err := validation.OutputFormat(opts.OutputFormat); err != nil {
 		return err
 	}
 

--- a/pkg/rakkess/validation/validation.go
+++ b/pkg/rakkess/validation/validation.go
@@ -31,10 +31,10 @@ func Options(opts *options.RakkessOptions) error {
 	if err := verbs(opts.Verbs); err != nil {
 		return err
 	}
-	return outputFormat(opts.OutputFormat)
+	return OutputFormat(opts.OutputFormat)
 }
 
-func outputFormat(format string) error {
+func OutputFormat(format string) error {
 	for _, o := range constants.ValidOutputFormats {
 		if o == format {
 			return nil

--- a/pkg/rakkess/validation/validation_test.go
+++ b/pkg/rakkess/validation/validation_test.go
@@ -41,7 +41,7 @@ func TestOutputFormat(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			actual := outputFormat(test.format)
+			actual := OutputFormat(test.format)
 			if test.expected != "" {
 				assert.EqualError(t, actual, test.expected)
 			} else {


### PR DESCRIPTION
PodSecurityPolicies usually have a ClusterRole with verb "use". As the verbs in clusterroles is arbitrary anyway, it is now allowed to evaluate for arbitrary words.

Close #30.