### PR TITLE
[travis] Remove obsolete `GOPROXY` and `GO111MODULE` setting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,6 @@ os:
 go:
 - 1.13.x
 
-env:
-  global:
-  - GO111MODULE=on
-  - GOPROXY=https://proxy.golang.org
-
 before_install:
   - go mod download
 


### PR DESCRIPTION
Both settings just re-iterate their defaults since go-1.13