### PR TITLE
Strip custom throttling

### DIFF
--- a/internal/client/resource_access_test.go
+++ b/internal/client/resource_access_test.go
@@ -31,19 +31,19 @@ import (
 
 type SelfSubjectAccessReviewDecision struct {
 	v1.ResourceAttributes
-	decision int
+	decision result.Access
 }
 
 func (d *SelfSubjectAccessReviewDecision) matches(other *v1.SelfSubjectAccessReview) bool {
 	return d.ResourceAttributes == *other.Spec.ResourceAttributes
 }
 
-type accessResult map[string]int
+type accessResult map[string]result.Access
 
 func buildAccess() accessResult {
-	return make(map[string]int)
+	return make(map[string]result.Access)
 }
-func (a accessResult) withResult(result int, verbs ...string) accessResult {
+func (a accessResult) withResult(result result.Access, verbs ...string) accessResult {
 	for _, v := range verbs {
 		a[v] = result
 	}
@@ -55,7 +55,7 @@ func (a accessResult) allowed(verbs ...string) accessResult {
 func (a accessResult) denied(verbs ...string) accessResult {
 	return a.withResult(result.AccessDenied, verbs...)
 }
-func (a accessResult) get() map[string]int {
+func (a accessResult) get() map[string]result.Access {
 	return a
 }
 

--- a/internal/client/result/resource.go
+++ b/internal/client/result/resource.go
@@ -28,7 +28,7 @@ type ResourceAccessItem struct {
 	// Name is the resource name.
 	Name string
 	// Access maps from verb to access code.
-	Access map[string]int
+	Access map[string]Access
 }
 
 // ResourceAccess holds the access result for all resources.

--- a/internal/client/result/resource_test.go
+++ b/internal/client/result/resource_test.go
@@ -24,8 +24,8 @@ import (
 )
 
 func TestSortResult(t *testing.T) {
-	makeResult := func(key string, value int) map[string]int {
-		result := make(map[string]int)
+	makeResult := func(key string, value Access) map[string]Access {
+		result := make(map[string]Access)
 		result[key] = value
 		return result
 	}
@@ -68,7 +68,7 @@ func TestSortResult(t *testing.T) {
 }
 
 func TestResourceAccess_Print(t *testing.T) {
-	evenYesOddNo := func(i int) string {
+	evenYesOddNo := func(i Access) string {
 		if i%2 == 0 {
 			return "yes"
 		}
@@ -85,7 +85,7 @@ func TestResourceAccess_Print(t *testing.T) {
 			items: []ResourceAccessItem{
 				{
 					Name:   "resource1",
-					Access: map[string]int{"list": 1, "get": 2, "delete": 3},
+					Access: map[string]Access{"list": 1, "get": 2, "delete": 3},
 				},
 			},
 			verbs:    []string{"list", "get", "delete"},
@@ -96,7 +96,7 @@ func TestResourceAccess_Print(t *testing.T) {
 			items: []ResourceAccessItem{
 				{
 					Name:   "resource1",
-					Access: map[string]int{"list": 1, "get": 2, "delete": 3},
+					Access: map[string]Access{"list": 1, "get": 2, "delete": 3},
 				},
 			},
 			verbs:    []string{"list"},
@@ -107,15 +107,15 @@ func TestResourceAccess_Print(t *testing.T) {
 			items: []ResourceAccessItem{
 				{
 					Name:   "resource1",
-					Access: map[string]int{"list": 1},
+					Access: map[string]Access{"list": 1},
 				},
 				{
 					Name:   "resource2",
-					Access: map[string]int{"list": 1},
+					Access: map[string]Access{"list": 1},
 				},
 				{
 					Name:   "resource3",
-					Access: map[string]int{"list": 2},
+					Access: map[string]Access{"list": 2},
 				},
 			},
 			verbs:    []string{"list"},

--- a/internal/client/result/result.go
+++ b/internal/client/result/result.go
@@ -18,16 +18,18 @@ package result
 
 import "io"
 
+type Access uint8
+
 // This encodes the access of the given subject to the resource+verb combination.
 const (
-	AccessAllowed = iota
-	AccessDenied
+	AccessDenied Access = iota
+	AccessAllowed
 	AccessNotApplicable
 	AccessRequestErr
 )
 
 // CodeConverter converts an access code to a human-readable string.
-type CodeConverter func(int) string
+type CodeConverter func(Access) string
 
 // MatrixPrinter needs to be implemented by result types.
 type MatrixPrinter interface {

--- a/internal/client/result/subject.go
+++ b/internal/client/result/subject.go
@@ -156,13 +156,11 @@ func (sa *SubjectAccess) Print(w io.Writer, converter CodeConverter, requestedVe
 		}
 		fmt.Fprintf(w, "%s\t%s\t%s", subject.Name, subject.Kind, subject.Namespace)
 		for _, v := range requestedVerbs {
-			var code int
+			a := AccessDenied
 			if verbs.Has(v) {
-				code = AccessAllowed
-			} else {
-				code = AccessDenied
+				a = AccessAllowed
 			}
-			fmt.Fprintf(w, "\t%s", converter(code))
+			fmt.Fprintf(w, "\t%s", converter(a))
 		}
 		fmt.Fprint(w, "\n")
 	}

--- a/internal/client/result/subject_test.go
+++ b/internal/client/result/subject_test.go
@@ -183,7 +183,7 @@ func TestSubjectAccess_ResolveRoleRef(t *testing.T) {
 }
 
 func TestSubjectAccess_Print(t *testing.T) {
-	yesNoConverter := func(i int) string {
+	yesNoConverter := func(i Access) string {
 		if i == AccessAllowed {
 			return "yes"
 		}

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -57,7 +57,7 @@ func PrintResults(out io.Writer, requestedVerbs []string, outputFormat string, r
 	results.Print(w, codeConverter, requestedVerbs)
 }
 
-func humanreadableAccessCode(code int) string {
+func humanreadableAccessCode(code result.Access) string {
 	switch code {
 	case result.AccessAllowed:
 		return "✔" // ✓
@@ -72,11 +72,11 @@ func humanreadableAccessCode(code int) string {
 	}
 }
 
-func colorHumanreadableAccessCode(code int) string {
+func colorHumanreadableAccessCode(code result.Access) string {
 	return fmt.Sprintf("\xff\033[%dm\xff%s\xff\033[0m\xff", codeToColor(code), humanreadableAccessCode(code))
 }
 
-func codeToColor(code int) color {
+func codeToColor(code result.Access) color {
 	switch code {
 	case result.AccessAllowed:
 		return green
@@ -90,7 +90,7 @@ func codeToColor(code int) color {
 	return none
 }
 
-func asciiAccessCode(code int) string {
+func asciiAccessCode(code result.Access) string {
 	switch code {
 	case result.AccessAllowed:
 		return "yes"

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -25,12 +25,12 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-type accessResult map[string]int
+type accessResult map[string]result.Access
 
 func buildAccess() accessResult {
-	return make(map[string]int)
+	return make(map[string]result.Access)
 }
-func (a accessResult) withResult(result int, verbs ...string) accessResult {
+func (a accessResult) withResult(result result.Access, verbs ...string) accessResult {
 	for _, v := range verbs {
 		a[v] = result
 	}
@@ -42,7 +42,7 @@ func (a accessResult) allowed(verbs ...string) accessResult {
 func (a accessResult) denied(verbs ...string) accessResult {
 	return a.withResult(result.AccessDenied, verbs...)
 }
-func (a accessResult) get() map[string]int {
+func (a accessResult) get() map[string]result.Access {
 	return a
 }
 


### PR DESCRIPTION
The API client always restricts the QPS. Rakkess' resource client abstraction had an additional throttle to prevent more than 20 concurrent requests. This is now removed in favor of the builtin throttling mechanism.

This should help with #58 