### PR TITLE
Fix extra lines in output (issue #156)

### DIFF
--- a/internal/client/result/resource.go
+++ b/internal/client/result/resource.go
@@ -28,7 +28,7 @@ type ResourceAccess map[string]map[string]Access
 
 // Print implements MatrixPrinter.Print. It prints a tab-separated table with a header.
 func (ra ResourceAccess) Table(verbs []string) *printer.Table {
-	names := make([]string, len(ra))
+	var names []string
 	for name := range ra {
 		names = append(names, name)
 	}


### PR DESCRIPTION
Fixed the issue #156

```bash
$ go run main.go --namespace default
NAME                                                 LIST  CREATE  UPDATE  DELETE
bindings                                                   ✔
cephblockpools.ceph.rook.io                          ✔     ✔       ✔       ✔
cephclients.ceph.rook.io                             ✔     ✔       ✔       ✔
cephclusters.ceph.rook.io                            ✔     ✔       ✔       ✔
cephfilesystemmirrors.ceph.rook.io                   ✔     ✔       ✔       ✔
cephfilesystems.ceph.rook.io                         ✔     ✔       ✔       ✔
cephnfses.ceph.rook.io                               ✔     ✔       ✔       ✔
cephobjectrealms.ceph.rook.io                        ✔     ✔       ✔       ✔
cephobjectstores.ceph.rook.io                        ✔     ✔       ✔       ✔
cephobjectstoreusers.ceph.rook.io                    ✔     ✔       ✔       ✔
cephobjectzonegroups.ceph.rook.io                    ✔     ✔       ✔       ✔
cephobjectzones.ceph.rook.io                         ✔     ✔       ✔       ✔
cephrbdmirrors.ceph.rook.io                          ✔     ✔       ✔       ✔
......
```