### PR TITLE
Sort by API group and consider all subresources in resource view, and respect API group in subject view

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,6 @@ require (
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/corneliusweig/tabwriter v0.0.0-20190512204542-5f8a091e83b5
 	github.com/googleapis/gnostic v0.4.1
-	github.com/gregjones/httpcache v0.0.0-20190212212710-3befbb6ad0cc // indirect
-	github.com/imdario/mergo v0.3.7 // indirect
 	github.com/konsorten/go-windows-terminal-sequences v1.0.3
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.2.1
@@ -18,4 +16,63 @@ require (
 	k8s.io/klog/v2 v2.80.1
 )
 
-go 1.16
+require (
+	cloud.google.com/go v0.81.0 // indirect
+	github.com/Azure/go-autorest v14.2.0+incompatible // indirect
+	github.com/Azure/go-autorest/autorest v0.11.12 // indirect
+	github.com/Azure/go-autorest/autorest/adal v0.9.5 // indirect
+	github.com/Azure/go-autorest/autorest/date v0.3.0 // indirect
+	github.com/Azure/go-autorest/logger v0.2.0 // indirect
+	github.com/Azure/go-autorest/tracing v0.6.0 // indirect
+	github.com/PuerkitoBio/purell v1.1.1 // indirect
+	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/evanphx/json-patch v4.9.0+incompatible // indirect
+	github.com/form3tech-oss/jwt-go v3.2.2+incompatible // indirect
+	github.com/go-errors/errors v1.0.1 // indirect
+	github.com/go-logr/logr v1.2.0 // indirect
+	github.com/go-openapi/jsonpointer v0.19.3 // indirect
+	github.com/go-openapi/jsonreference v0.19.3 // indirect
+	github.com/go-openapi/spec v0.19.5 // indirect
+	github.com/go-openapi/swag v0.19.5 // indirect
+	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/google/btree v1.0.0 // indirect
+	github.com/google/go-cmp v0.5.5 // indirect
+	github.com/google/gofuzz v1.1.0 // indirect
+	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
+	github.com/google/uuid v1.1.2 // indirect
+	github.com/gregjones/httpcache v0.0.0-20190212212710-3befbb6ad0cc // indirect
+	github.com/imdario/mergo v0.3.7 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/json-iterator/go v1.1.11 // indirect
+	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de // indirect
+	github.com/mailru/easyjson v0.7.0 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.1 // indirect
+	github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 // indirect
+	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/xlab/treeprint v0.0.0-20181112141820-a009c3971eca // indirect
+	go.starlark.net v0.0.0-20200306205701-8dd3e2ee1dd5 // indirect
+	golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83 // indirect
+	golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4 // indirect
+	golang.org/x/oauth2 v0.0.0-20210402161424-2e8d93401602 // indirect
+	golang.org/x/sys v0.0.0-20210510120138-977fb7262007 // indirect
+	golang.org/x/text v0.3.5 // indirect
+	golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba // indirect
+	google.golang.org/appengine v1.6.7 // indirect
+	google.golang.org/protobuf v1.26.0 // indirect
+	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
+	k8s.io/kube-openapi v0.0.0-20210305001622-591a79e4bda7 // indirect
+	k8s.io/utils v0.0.0-20201110183641-67b214c5f920 // indirect
+	sigs.k8s.io/kustomize/api v0.8.8 // indirect
+	sigs.k8s.io/kustomize/kyaml v0.10.17 // indirect
+	sigs.k8s.io/structured-merge-diff/v4 v4.1.0 // indirect
+	sigs.k8s.io/yaml v1.2.0 // indirect
+)
+
+go 1.20

--- a/internal/client/fetch_resources.go
+++ b/internal/client/fetch_resources.go
@@ -80,7 +80,12 @@ func FetchAvailableGroupResources(opts *options.RakkessOptions) ([]GroupResource
 			klog.Warningf("Cannot parse groupVersion: %s", err)
 			continue
 		}
-		for _, r := range list.APIResources {
+		resourceListWithSubresources, err := client.ServerResourcesForGroupVersion(list.GroupVersion)
+		if err != nil {
+			klog.Warningf("Cannot parse get all resources for gv: %s %s", list.GroupVersion, err)
+			continue
+		}
+		for _, r := range resourceListWithSubresources.APIResources {
 			if len(r.Verbs) == 0 {
 				continue
 			}

--- a/internal/client/fetch_resources_test.go
+++ b/internal/client/fetch_resources_test.go
@@ -61,7 +61,7 @@ func (c *fakeCachedDiscoveryInterface) ServerGroupsAndResources() ([]*metav1.API
 }
 
 func (c *fakeCachedDiscoveryInterface) ServerResourcesForGroupVersion(groupVersion string) (*metav1.APIResourceList, error) {
-	panic("not implemented")
+	return &c.next, nil
 }
 
 func (c *fakeCachedDiscoveryInterface) ServerResources() ([]*metav1.APIResourceList, error) {

--- a/internal/client/result/resource.go
+++ b/internal/client/result/resource.go
@@ -17,10 +17,12 @@ limitations under the License.
 package result
 
 import (
+	"cmp"
 	"sort"
 	"strings"
 
 	"github.com/corneliusweig/rakkess/internal/printer"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 // ResourceAccess holds the access result for all resources.
@@ -28,25 +30,49 @@ type ResourceAccess map[string]map[string]Access
 
 // Print implements MatrixPrinter.Print. It prints a tab-separated table with a header.
 func (ra ResourceAccess) Table(verbs []string) *printer.Table {
-	var names []string
+	var groupResources []schema.GroupResource
 	for name := range ra {
-		names = append(names, name)
+		groupResources = append(groupResources, schema.ParseGroupResource(name))
 	}
-	sort.Strings(names)
+	sort.Slice(groupResources, func(i, j int) bool {
+		x := groupResources[i]
+		y := groupResources[j]
+		// first sort by group, then resource
+		if x.Group != y.Group {
+			return cmp.Less(x.Group, y.Group)
+		}
+		return cmp.Less(x.Resource, y.Resource)
+	})
 
-	// table header
-	headers := []string{"NAME"}
+	upperVerbs := make([]string, 0, len(verbs))
 	for _, v := range verbs {
-		headers = append(headers, strings.ToUpper(v))
+		upperVerbs = append(upperVerbs, strings.ToUpper(v))
 	}
 
-	p := printer.TableWithHeaders(headers)
+	p := printer.TableWithHeaders(nil)
 
 	// table body
-	for _, name := range names {
+	lastGroup := ""
+	for i, gr := range groupResources {
+		// print the API group and verbs when the API group changes, or for the first API group (which often is "")
+		if gr.Group != lastGroup || i == 0 {
+
+			if i != 0 {
+				p.AddRow([]string{" "}, printer.None) // at least one "none" outcome needed to get the tabprinter aligning all columns
+			}
+
+			displayGroup := gr.Group
+			if displayGroup == "" {
+				displayGroup = "core"
+			}
+
+			p.AddRow(append([]string{displayGroup + ":"}, upperVerbs...), printer.None)
+			lastGroup = gr.Group
+		}
+
 		var outcomes []printer.Outcome
 
-		res := ra[name]
+		res := ra[gr.String()]
 		for _, v := range verbs {
 			var o printer.Outcome
 			switch res[v] {
@@ -61,7 +87,7 @@ func (ra ResourceAccess) Table(verbs []string) *printer.Table {
 			}
 			outcomes = append(outcomes, o)
 		}
-		p.AddRow([]string{name}, outcomes...)
+		p.AddRow([]string{gr.Resource}, outcomes...)
 	}
 	return p
 }

--- a/internal/client/subject_access.go
+++ b/internal/client/subject_access.go
@@ -22,6 +22,7 @@ import (
 	"github.com/corneliusweig/rakkess/internal/client/result"
 	"github.com/corneliusweig/rakkess/internal/options"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	clientv1 "k8s.io/client-go/kubernetes/typed/rbac/v1"
 	"k8s.io/klog/v2"
 )
@@ -37,7 +38,7 @@ const (
 )
 
 // GetSubjectAccess determines subjects with access to the given resource.
-func GetSubjectAccess(ctx context.Context, opts *options.RakkessOptions, resource, resourceName string) (*result.SubjectAccess, error) {
+func GetSubjectAccess(ctx context.Context, opts *options.RakkessOptions, gr schema.GroupResource, resourceName string) (*result.SubjectAccess, error) {
 	rbacClient, err := getRbacClient(opts)
 	if err != nil {
 		return nil, err
@@ -46,7 +47,7 @@ func GetSubjectAccess(ctx context.Context, opts *options.RakkessOptions, resourc
 	namespace := opts.ConfigFlags.Namespace
 	isNamespace := namespace != nil && *namespace != ""
 
-	sa := result.NewSubjectAccess(resource, resourceName)
+	sa := result.NewSubjectAccess(gr, resourceName)
 
 	if err := fetchMatchingClusterRoles(ctx, rbacClient, sa); err != nil {
 		if !isNamespace {

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -93,7 +93,9 @@ func (p *Table) Render(out io.Writer, outputFormat string) {
 			fmt.Fprintf(w, "\t%s", h)
 		}
 	}
-	fmt.Fprint(w, "\n")
+	if len(p.Headers) != 0 {
+		fmt.Fprint(w, "\n")
+	}
 
 	// table body
 	for _, row := range p.Rows {

--- a/internal/rakkess.go
+++ b/internal/rakkess.go
@@ -55,7 +55,7 @@ func Resource(ctx context.Context, opts *options.RakkessOptions) (result.Resourc
 // Subject determines the subjects with access right to the given resource and
 // prints the result as a matrix with verbs in the horizontal and subject names
 // in the vertical direction.
-func Subject(ctx context.Context, opts *options.RakkessOptions, resource, resourceName string) error {
+func Subject(ctx context.Context, opts *options.RakkessOptions, resourceWithOptionalAPIGroup, resourceName string) error {
 	if err := validation.OutputFormat(opts.OutputFormat); err != nil {
 		return err
 	}
@@ -64,12 +64,15 @@ func Subject(ctx context.Context, opts *options.RakkessOptions, resource, resour
 	if err != nil {
 		return errors.Wrap(err, "cannot create k8s REST mapper")
 	}
-	versionedResource, err := mapper.ResourceFor(schema.GroupVersionResource{Resource: resource})
+
+	// the apiGroup might be unspecified in the query, but will be populated in the response if there were only one such resource
+	gr := schema.ParseGroupResource(resourceWithOptionalAPIGroup)
+	versionedResource, err := mapper.ResourceFor(schema.GroupVersionResource{Resource: gr.Resource, Group: gr.Group})
 	if err != nil {
 		return errors.Wrap(err, "determine requested resource")
 	}
 
-	subjectAccess, err := client.GetSubjectAccess(ctx, opts, versionedResource.Resource, resourceName)
+	subjectAccess, err := client.GetSubjectAccess(ctx, opts, versionedResource.GroupResource(), resourceName)
 	if err != nil {
 		return errors.Wrap(err, "get subject access")
 	}


### PR DESCRIPTION
Hi 👋 ! Thanks a lot for this project!

Here's a couple of improvements (at least in my opinion, let me know what you think 😄) to the project:

- Text output in resource view is now sorted by API group, so it's easier for a human reviewer of the output to look at similar resources together. Also it is easier to read what the name of the resource is when the api group name is not duplicated for every resource.
- Previously, subresources like `/status` and `/scale`, or importantly `serviceaccounts/token` or `certificatesigningrequests/approval`, were not listed. By looking up all resources within a groupversion, we now include this data in the output.
- API group was not taken into account in the subject view, which means that if there was an RBAC rule that gave a user access to `deployments.mycustomgroup`, it would look like that user also had access to `deployments.apps`

Let me know what you think about these!